### PR TITLE
Add text block edit functionality

### DIFF
--- a/src/components/digests/block-card/text-card/TextCard.tsx
+++ b/src/components/digests/block-card/text-card/TextCard.tsx
@@ -66,7 +66,7 @@ export default function BlockTextCard({ block, isEditable = false }: Props) {
             setIsOpen={setIsEditDialogOpen}
             bookmarkDigest={block}
             defaultValues={{
-              ...(block.text && { text: block.text }),
+              text: block.text,
             }}
           />
         </>

--- a/src/components/digests/block-card/text-card/TextCard.tsx
+++ b/src/components/digests/block-card/text-card/TextCard.tsx
@@ -8,6 +8,7 @@ import { useTeam } from '@/contexts/TeamContext';
 import { useParams } from 'next/navigation';
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
 import ActionsBlockPopover from '../../ActionsBlockPopover';
+import EditTextBlockDialog from '../../dialog/EditTextBlockDialog';
 
 export interface Props {
   block: PublicDigestListProps['digest']['digestBlocks'][number];
@@ -15,6 +16,7 @@ export interface Props {
 }
 
 export default function BlockTextCard({ block, isEditable = false }: Props) {
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const { id: teamId } = useTeam();
   const params = useParams();
   const { remove, isRefreshing } = useAddAndRemoveBlockOnDigest({
@@ -27,6 +29,7 @@ export default function BlockTextCard({ block, isEditable = false }: Props) {
       'BlockTextCard: block.text is null, but it should not be null.'
     );
   }
+
   const htmlContent = remark().use(html).processSync(block.text);
 
   return (
@@ -50,10 +53,23 @@ export default function BlockTextCard({ block, isEditable = false }: Props) {
         </div>
       </div>
       {isEditable && (
-        <ActionsBlockPopover
-          isRemoving={remove.isLoading || isRefreshing}
-          onRemoveClick={() => remove.mutate(block.id)}
-        />
+        <>
+          <ActionsBlockPopover
+            isRemoving={remove.isLoading || isRefreshing}
+            onRemoveClick={() => remove.mutate(block.id)}
+            onEditClick={() => {
+              setIsEditDialogOpen(true);
+            }}
+          />
+          <EditTextBlockDialog
+            isOpen={isEditDialogOpen}
+            setIsOpen={setIsEditDialogOpen}
+            bookmarkDigest={block}
+            defaultValues={{
+              ...(block.text && { text: block.text }),
+            }}
+          />
+        </>
       )}
     </div>
   );

--- a/src/components/digests/dialog/AddTextBlockDialog.tsx
+++ b/src/components/digests/dialog/AddTextBlockDialog.tsx
@@ -96,7 +96,7 @@ export default function AddTextBlockDialog({
               disabled={!isDirty}
               isLoading={isCreating || isRefreshing}
             >
-              Save
+              Add
             </Button>
             <Button
               type="button"

--- a/src/components/digests/dialog/EditTextBlockDialog.tsx
+++ b/src/components/digests/dialog/EditTextBlockDialog.tsx
@@ -58,7 +58,7 @@ export default function EditTextBlockDialog({
     },
     {
       onSuccess: () => {
-        successToast('Bookmark updated');
+        successToast('Digest updated');
         closeDialog();
         refresh();
       },

--- a/src/components/digests/dialog/EditTextBlockDialog.tsx
+++ b/src/components/digests/dialog/EditTextBlockDialog.tsx
@@ -24,7 +24,7 @@ interface Props {
   defaultValues?: Partial<FormValues>;
 }
 
-export default function EditBookmarkDialog({
+export default function EditTextBlockDialog({
   isOpen,
   setIsOpen,
   bookmarkDigest,

--- a/src/components/digests/dialog/EditTextBlockDialog.tsx
+++ b/src/components/digests/dialog/EditTextBlockDialog.tsx
@@ -1,0 +1,130 @@
+import { useTeam } from '@/contexts/TeamContext';
+import useCustomToast from '@/hooks/useCustomToast';
+import useTransitionRefresh from '@/hooks/useTransitionRefresh';
+import api from '@/lib/api';
+import { getTweetId, isTwitterLink } from '@/utils/link';
+import { BookmarkDigestStyle } from '@prisma/client';
+import { AxiosError, AxiosResponse } from 'axios';
+import { useParams } from 'next/navigation';
+import React, { useEffect } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useMutation } from 'react-query';
+import Button from '../../Button';
+import { Dialog, DialogContent } from '../../Dialog';
+import { TextArea } from '../../Input';
+import { Props as BookmarkCardProps } from '../block-card/BlockCard';
+
+interface FormValues {
+  text: string;
+}
+interface Props {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  bookmarkDigest: BookmarkCardProps['block'];
+  defaultValues?: Partial<FormValues>;
+}
+
+export default function EditBookmarkDialog({
+  isOpen,
+  setIsOpen,
+  bookmarkDigest,
+  defaultValues,
+}: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+    reset,
+  } = useForm<FormValues>({
+    defaultValues,
+  });
+  const { successToast, errorToast } = useCustomToast();
+  const { isRefreshing, refresh } = useTransitionRefresh();
+
+  const params = useParams();
+  const { id: teamId } = useTeam();
+
+  const { mutate: updateBookDigest, isLoading: isRemoving } = useMutation<
+    AxiosResponse,
+    AxiosError<ErrorResponse>,
+    FormValues
+  >(
+    'update-bookmarkdigest',
+    ({ text }) => {
+      return api.patch(
+        `/teams/${teamId}/digests/${params?.digestId}/block/${bookmarkDigest.id}`,
+        { text }
+      );
+    },
+    {
+      onSuccess: () => {
+        successToast('Bookmark updated');
+        closeDialog();
+        refresh();
+      },
+      onError: (error: AxiosError<ErrorResponse>) => {
+        errorToast(
+          error.response?.data?.error ||
+            error.response?.statusText ||
+            error.message ||
+            'Something went wrong'
+        );
+      },
+    }
+  );
+
+  const onSubmit: SubmitHandler<FormValues> = (data: FormValues) => {
+    updateBookDigest(data);
+  };
+
+  function closeDialog() {
+    reset();
+    setIsOpen(false);
+  }
+
+  useEffect(() => {
+    if (Object.keys(errors).length > 0) {
+      Object.values(errors).forEach((error) => {
+        if (error.message) {
+          errorToast(error.message);
+        }
+      });
+    }
+  }, [errors, errorToast]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={() => setIsOpen(!open)}>
+      <DialogContent
+        title="Edit bookmark"
+        closeIcon
+        containerClassName="w-full sm:max-w-3xl"
+      >
+        <form
+          className="flex flex-col items-end mt-4 gap-6 w-full max-w-3xl"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <fieldset className="flex flex-col gap-2 w-full">
+            <label htmlFor="description">Description</label>
+            <TextArea className="min-h-[10rem]" {...register('text')} />
+          </fieldset>
+          <div className="flex justify-start gap-4 w-full items-center">
+            <Button
+              isLoading={isRemoving || isRefreshing}
+              type="submit"
+              disabled={!isDirty}
+            >
+              Save
+            </Button>
+            <Button
+              type="button"
+              variant="destructiveGhost"
+              onClick={closeDialog}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/digests/dialog/EditTextBlockDialog.tsx
+++ b/src/components/digests/dialog/EditTextBlockDialog.tsx
@@ -2,8 +2,6 @@ import { useTeam } from '@/contexts/TeamContext';
 import useCustomToast from '@/hooks/useCustomToast';
 import useTransitionRefresh from '@/hooks/useTransitionRefresh';
 import api from '@/lib/api';
-import { getTweetId, isTwitterLink } from '@/utils/link';
-import { BookmarkDigestStyle } from '@prisma/client';
 import { AxiosError, AxiosResponse } from 'axios';
 import { useParams } from 'next/navigation';
 import React, { useEffect } from 'react';
@@ -40,6 +38,10 @@ export default function EditTextBlockDialog({
   });
   const { successToast, errorToast } = useCustomToast();
   const { isRefreshing, refresh } = useTransitionRefresh();
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
 
   const params = useParams();
   const { id: teamId } = useTeam();

--- a/src/components/digests/dialog/EditTextBlockDialog.tsx
+++ b/src/components/digests/dialog/EditTextBlockDialog.tsx
@@ -95,7 +95,8 @@ export default function EditBookmarkDialog({
   return (
     <Dialog open={isOpen} onOpenChange={() => setIsOpen(!open)}>
       <DialogContent
-        title="Edit bookmark"
+        title="Edit a text block"
+        description="Write something to add to your digest, markdown is supported."
         closeIcon
         containerClassName="w-full sm:max-w-3xl"
       >
@@ -103,10 +104,12 @@ export default function EditBookmarkDialog({
           className="flex flex-col items-end mt-4 gap-6 w-full max-w-3xl"
           onSubmit={handleSubmit(onSubmit)}
         >
-          <fieldset className="flex flex-col gap-2 w-full">
-            <label htmlFor="description">Description</label>
-            <TextArea className="min-h-[10rem]" {...register('text')} />
-          </fieldset>
+          <TextArea
+            className="min-h-[10rem]"
+            placeholder="Write something..."
+            {...register('text')}
+            rows={10}
+          />
           <div className="flex justify-start gap-4 w-full items-center">
             <Button
               isLoading={isRemoving || isRefreshing}


### PR DESCRIPTION
Hi 👋🏻,

To add the ability of editing text blocks, I quickly duplicated the `EditBookmarkCard` file and modified the `.../{digestId}/block/{blockId}` endpoint `PATCH` implementation. Adding an `onEditClick` prop to the `BlockTextCard` component to show the `Edit` button in the Block Menu Popover.

Didn't test intensively, but it should work fine 😄 

## Improvements
- Merge `AddTextBlockDialog` and `EditTextBlockDialog` into one component?
- Cleanup the `.../{digestId}/block/{blockId}` file to avoid nesting. Factorize `if-else` statement in functions?