### PR TITLE
feat: update the style of the newsletter to match the web version

### DIFF
--- a/src/components/pages/DigestEditPage.tsx
+++ b/src/components/pages/DigestEditPage.tsx
@@ -224,7 +224,7 @@ export const DigestEditPage = ({
               <Button
                 className="flex-1"
                 aria-label={`${
-                  digest?.publishedAt ? 'Unpublished' : 'Publish'
+                  digest?.publishedAt ? 'Unpublish' : 'Publish'
                 } digest`}
                 variant="outline"
                 icon={digest.publishedAt ? <EyeSlashIcon /> : <RssIcon />}
@@ -233,7 +233,7 @@ export const DigestEditPage = ({
                   digest?.publishedAt ? draft() : publish();
                 }}
               >
-                {!!digest?.publishedAt ? 'Unpublished' : 'Publish'}
+                {!!digest?.publishedAt ? 'Unpublish' : 'Publish'}
               </Button>
               <DeletePopover
                 handleDelete={deleteDigest}

--- a/src/utils/newsletter/index.ts
+++ b/src/utils/newsletter/index.ts
@@ -1,6 +1,7 @@
 type Theme = {
   [key: string]: {
     fontSize: string;
+    fontFamily?: string;
     fontWeight: string;
     color: string;
     fontStyle?: string;
@@ -10,62 +11,74 @@ type Theme = {
 const defaultTheme: Theme = {
   h1: {
     fontSize: '16px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'bold',
     color: '#000000',
   },
   h2: {
     fontSize: '14px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'bold',
     color: '#000000',
   },
   h3: {
     fontSize: '14px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'normal',
     color: '#000000',
   },
   h4: {
     fontSize: '14px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'normal',
     color: '#000000',
   },
   h5: {
     fontSize: '14px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'normal',
     color: '#000000',
   },
   p: {
     fontSize: '13px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'normal',
     color: '#333333',
   },
   ul: {
     fontSize: '13px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'normal',
     color: '#333333',
   },
   ol: {
     fontSize: '13px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'normal',
     color: '#333333',
   },
   li: {
     fontSize: '13px',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'normal',
     color: '#333333',
   },
   strong: {
     color: 'inherit',
     fontSize: 'inherit',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'bold',
   },
   em: {
     fontSize: 'inherit',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'inherit',
     fontStyle: 'italic',
     color: 'inherit',
   },
   i: {
     fontSize: 'inherit',
+    fontFamily: 'Cantarell, sans-serif',
     fontWeight: 'inherit',
     fontStyle: 'italic',
     color: 'inherit',


### PR DESCRIPTION
Related: #17 

To test these changes:
- spin up a `MailDev`
- apply [my patch](https://gist.github.com/MrNossiom/d472a777ef8acc3e164e2adc4087e5d3)
- send the digest newsletter on your local dashboard.

Many things are not done yet:
- Choose the breakpoint width
- Apply styles to `Text` blocks (raw HTML) and change the default theme to have bigger `h1`, etc.
- How to display tweets that have `.style == TWEET_EMBED`

It looks like this:
![MailDev screenshot](https://github.com/premieroctet/digestclub/assets/43814157/35183969-0195-4d8b-add5-0c4adbdd6e1c)
