### PR TITLE
Trending bookmarks listing

### DIFF
--- a/src/app/(routes)/teams/[teamSlug]/digests/[digestId]/edit/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/digests/[digestId]/edit/page.tsx
@@ -3,7 +3,7 @@ import { TeamProvider } from '@/contexts/TeamContext';
 import {
   checkUserTeamBySlug,
   getDigest,
-  getTeamBookmarkedLinks,
+  getTeamLinks,
   updateDefaultTeam,
 } from '@/lib/queries';
 import { getCurrentUserOrRedirect } from '@/lib/sessions';
@@ -32,7 +32,7 @@ const page = async ({ params, searchParams }: TeamPageProps) => {
 
   const page = Number(searchParams?.page || 1);
   const search = searchParams?.search || '';
-  const bookmarkedLinksData = await getTeamBookmarkedLinks(team.id, {
+  const teamLinksData = await getTeamLinks(team.id, {
     page,
     onlyNotInDigest: true,
     search,
@@ -41,7 +41,7 @@ const page = async ({ params, searchParams }: TeamPageProps) => {
   return (
     <TeamProvider team={team}>
       <DigestEditPage
-        bookmarkedLinksData={bookmarkedLinksData}
+        teamLinksData={teamLinksData}
         digest={digest}
         team={team}
       />

--- a/src/app/(routes)/teams/[teamSlug]/digests/[digestId]/edit/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/digests/[digestId]/edit/page.tsx
@@ -3,7 +3,7 @@ import { TeamProvider } from '@/contexts/TeamContext';
 import {
   checkUserTeamBySlug,
   getDigest,
-  getTeamBookmarksNotInDigest,
+  getTeamBookmarkedLinks,
   updateDefaultTeam,
 } from '@/lib/queries';
 import { getCurrentUserOrRedirect } from '@/lib/sessions';
@@ -32,17 +32,16 @@ const page = async ({ params, searchParams }: TeamPageProps) => {
 
   const page = Number(searchParams?.page || 1);
   const search = searchParams?.search || '';
-  const dataBookmarks = await getTeamBookmarksNotInDigest(
-    team.id,
+  const bookmarkedLinksData = await getTeamBookmarkedLinks(team.id, {
     page,
-    10,
-    search
-  );
+    onlyNotInDigest: true,
+    search,
+  });
 
   return (
     <TeamProvider team={team}>
       <DigestEditPage
-        dataBookmarks={dataBookmarks}
+        bookmarkedLinksData={bookmarkedLinksData}
         digest={digest}
         team={team}
       />

--- a/src/app/(routes)/teams/[teamSlug]/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/page.tsx
@@ -2,7 +2,7 @@ import Team from '@/components/pages/Team';
 import db from '@/lib/db';
 import {
   checkUserTeamBySlug,
-  getTeamBookmarks,
+  getTeamBookmarkedLinks,
   getTeamDigests,
   updateDefaultTeam,
 } from '@/lib/queries';
@@ -39,11 +39,14 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
 
   const page = Number(searchParams?.page || 1);
   const search = searchParams?.search || '';
-  const { totalCount, bookmarks } = await getTeamBookmarks(team.id, {
-    page,
-    onlyNotInDigest: !searchParams?.all,
-    search,
-  });
+  const { totalCount, bookmarkedLinks } = await getTeamBookmarkedLinks(
+    team.id,
+    {
+      page,
+      onlyNotInDigest: !searchParams?.all,
+      search,
+    }
+  );
 
   const digests = await getTeamDigests(team.id, 1, 11);
 
@@ -51,7 +54,7 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
     <Team
       team={team}
       linkCount={totalCount}
-      bookmarks={bookmarks}
+      bookmarkedLinks={bookmarkedLinks}
       digests={digests}
       search={search}
     />

--- a/src/app/(routes)/teams/[teamSlug]/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/page.tsx
@@ -2,7 +2,7 @@ import Team from '@/components/pages/Team';
 import db from '@/lib/db';
 import {
   checkUserTeamBySlug,
-  getTeamBookmarkedLinks,
+  getTeamLinks,
   getTeamDigests,
   updateDefaultTeam,
 } from '@/lib/queries';
@@ -39,14 +39,11 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
 
   const page = Number(searchParams?.page || 1);
   const search = searchParams?.search || '';
-  const { totalCount, bookmarkedLinks } = await getTeamBookmarkedLinks(
-    team.id,
-    {
-      page,
-      onlyNotInDigest: !searchParams?.all,
-      search,
-    }
-  );
+  const { totalCount, teamLinks } = await getTeamLinks(team.id, {
+    page,
+    onlyNotInDigest: !searchParams?.all,
+    search,
+  });
 
   const digests = await getTeamDigests(team.id, 1, 11);
 
@@ -54,7 +51,7 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
     <Team
       team={team}
       linkCount={totalCount}
-      bookmarkedLinks={bookmarkedLinks}
+      teamLinks={teamLinks}
       digests={digests}
       search={search}
     />

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -3,7 +3,6 @@
 import { Toaster } from 'react-hot-toast';
 import { SessionProvider } from 'next-auth/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import messages from '../messages/en.json';
 
 const locale = 'en';
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -63,7 +63,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps<any>>(
 );
 
 export const Switch = forwardRef<HTMLInputElement, HTMLProps<HTMLInputElement>>(
-  function Switch({ label, onClick, checked, ...props }, ref) {
+  function Switch({ label, onChange, checked, ...props }, ref) {
     const [isChecked, setIsChecked] = useState(checked);
     return (
       <label className="relative inline-flex  cursor-pointer">
@@ -72,9 +72,9 @@ export const Switch = forwardRef<HTMLInputElement, HTMLProps<HTMLInputElement>>(
             type="checkbox"
             checked={isChecked}
             className="sr-only peer"
-            onClick={(e) => {
+            onChange={(e) => {
               setIsChecked(!isChecked);
-              onClick && onClick(e);
+              onChange && onChange(e);
             }}
             ref={ref}
             {...props}

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -105,7 +105,7 @@ export const MultipleDeletePopover = forwardRef<
     >
       <div className="flex-col z-20">
         {bookmarks.map((bookmark) => (
-          <div className="flex items-center pb-4" key={bookmark?.id}>
+          <div className="flex items-center justify-between" key={bookmark?.id}>
             <div className="pr-4">{getContributor(bookmark)}</div>
             <DeletePopover
               handleDelete={() => onDelete(bookmark?.id)}

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -7,6 +7,9 @@ import {
 } from '@radix-ui/react-popover';
 import { ReactElement, cloneElement, forwardRef } from 'react';
 import Button from './Button';
+import { TeamBookmarkedLinkItem } from '@/lib/queries';
+import { getContributor } from './bookmark/BookmarkItem';
+import { TrashIcon } from '@heroicons/react/24/solid';
 
 interface DeletePopoverProps {
   trigger?: ReactElement;
@@ -29,7 +32,7 @@ export const Popover = forwardRef<HTMLButtonElement, PopoverProps & IProps>(
         </Trigger>
         <Portal>
           <Content>
-            <div className="text-sm flex mt-3 items-center justify-between space-x-8 border rounded-md bg-white p-2 text-gray-700 shadow-lg">
+            <div className="text-sm flex mt-3 items-center justify-between space-x-8 border rounded-md bg-white p-2 text-gray-700 shadow-lg z-50">
               {children}
             </div>
           </Content>
@@ -75,3 +78,52 @@ export const DeletePopover = forwardRef<HTMLButtonElement, DeletePopoverProps>(
 );
 
 DeletePopover.displayName = 'DeletePopover';
+
+export const MultipleDeletePopover = forwardRef<
+  HTMLButtonElement,
+  {
+    onDelete: (bookmarkId: string) => void;
+    bookmarks: TeamBookmarkedLinkItem['bookmark'];
+    trigger?: ReactElement;
+    isLoading: boolean;
+  }
+>(function MultipleDeletePopover(props, ref) {
+  const { bookmarks, onDelete, isLoading } = props;
+
+  return (
+    <Popover
+      trigger={
+        props.trigger || (
+          <span
+            ref={ref}
+            className="text-xs font-semibold hover:underline cursor-pointer"
+          >
+            Delete
+          </span>
+        )
+      }
+    >
+      <div className="flex-col z-20">
+        {bookmarks.map((bookmark) => (
+          <div className="flex items-center pb-4" key={bookmark?.id}>
+            <div className="pr-4">{getContributor(bookmark)}</div>
+            <DeletePopover
+              handleDelete={() => onDelete(bookmark?.id)}
+              isLoading={isLoading}
+              trigger={
+                <Button
+                  aria-label="Delete digest"
+                  icon={<TrashIcon />}
+                  variant="destructiveGhost"
+                  isLoading={isLoading}
+                />
+              }
+            />
+          </div>
+        ))}
+      </div>
+    </Popover>
+  );
+});
+
+MultipleDeletePopover.displayName = 'MultipleDeletePopover';

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -26,7 +26,7 @@ export const Tooltip = ({
           <Content
             side="bottom"
             sideOffset={5}
-            className="shadow-md bg-gray-600 text-xs text-white rounded-md p-2"
+            className="shadow-md bg-gray-600 text-xs text-white rounded-md p-2 z-20"
           >
             {children}
             <Arrow className="fill-gray-600" />

--- a/src/components/bookmark/Bookmark.tsx
+++ b/src/components/bookmark/Bookmark.tsx
@@ -1,5 +1,5 @@
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
-import { TeamBookmarkedLinks } from '@/lib/queries';
+import { TeamBookmarkedLinkItem, TeamBookmarkedLinks } from '@/lib/queries';
 import { PlusCircleIcon } from '@heroicons/react/24/solid';
 import { DigestBlockType } from '@prisma/client';
 import { AiOutlineLoading3Quarters as LoadingIcon } from '@react-icons/all-files/ai/AiOutlineLoading3Quarters';
@@ -8,11 +8,11 @@ import { PropsWithChildren } from 'react';
 import BookmarkImage from './BookmarkImage';
 
 export const Bookmark = ({
-  bookmark,
+  bookmarkedLink,
   teamId,
   digestId,
 }: {
-  bookmark: TeamBookmarkedLinks;
+  bookmarkedLink: TeamBookmarkedLinkItem;
   teamId: string;
   digestId: string;
 } & PropsWithChildren) => {
@@ -25,19 +25,19 @@ export const Bookmark = ({
       <div className="flex w-full justify-between">
         <div className="flex gap-2 overflow-hidden w-[100%] justify-start">
           <div className="relative w-16 h-16 overflow-hidden rounded-md border max-w-[4rem]">
-            <BookmarkImage link={bookmark.link} />
+            <BookmarkImage link={bookmarkedLink} />
           </div>
           <div className="flex flex-col items-start max-w-[100%] overflow-hidden flex-1">
             <div className="flex flex-col overflow-hidden max-w-[100%]">
               <p className="font-semibold whitespace-nowrap overflow-hidden text-ellipsis text-base text-gray-800">
-                {bookmark.link.title}
+                {bookmarkedLink.title}
               </p>
               <Link
-                href={bookmark.link.url}
+                href={bookmarkedLink.url}
                 target="_blank"
                 className="text-gray-400 whitespace-nowrap overflow-hidden text-ellipsis text-base underline underline-offset-2"
               >
-                {bookmark.link.url}
+                {bookmarkedLink.url}
               </Link>
             </div>
           </div>
@@ -49,7 +49,7 @@ export const Bookmark = ({
             onClick={(e) => {
               e.preventDefault();
               add.mutate({
-                bookmarkId: bookmark.id,
+                bookmarkId: bookmarkedLink.id,
                 type: DigestBlockType.BOOKMARK,
               });
             }}

--- a/src/components/bookmark/Bookmark.tsx
+++ b/src/components/bookmark/Bookmark.tsx
@@ -1,5 +1,5 @@
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
-import { TeamBookmarksResult } from '@/lib/queries';
+import { TeamBookmarkedLinks } from '@/lib/queries';
 import { PlusCircleIcon } from '@heroicons/react/24/solid';
 import { DigestBlockType } from '@prisma/client';
 import { AiOutlineLoading3Quarters as LoadingIcon } from '@react-icons/all-files/ai/AiOutlineLoading3Quarters';
@@ -12,7 +12,7 @@ export const Bookmark = ({
   teamId,
   digestId,
 }: {
-  bookmark: TeamBookmarksResult;
+  bookmark: TeamBookmarkedLinks;
   teamId: string;
   digestId: string;
 } & PropsWithChildren) => {

--- a/src/components/bookmark/BookmarkAddButton.tsx
+++ b/src/components/bookmark/BookmarkAddButton.tsx
@@ -1,20 +1,13 @@
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
-import { getTeamBookmarksNotInDigest } from '@/lib/queries';
-import Link from 'next/link';
+import { TeamBookmarkedLinkItem } from '@/lib/queries';
 import React from 'react';
-import BookmarkImage from '../bookmark/BookmarkImage';
 import { AiOutlineLoading3Quarters as LoadingIcon } from '@react-icons/all-files/ai/AiOutlineLoading3Quarters';
 import { PlusCircleIcon } from '@heroicons/react/24/solid';
-import { getRelativeDate } from '@/utils/date';
-import { getDomainFromUrl } from '@/utils/url';
 import { BookmarkDigestStyle, DigestBlockType } from '@prisma/client';
-import { getEnvHost } from '@/lib/server';
 import { isTwitterLink } from '@/utils/link';
 
 interface Props {
-  bookmark: Awaited<
-    ReturnType<typeof getTeamBookmarksNotInDigest>
-  >['bookmarks'][0];
+  bookmark: TeamBookmarkedLinkItem;
   teamId: string;
   digestId: string;
 }
@@ -39,9 +32,9 @@ export default function BookmarkAddButton({
         onClick={(e) => {
           e.preventDefault();
           add.mutate({
-            bookmarkId: bookmark.id,
+            bookmarkId: bookmark.bookmark[0].id,
             type: DigestBlockType.BOOKMARK,
-            style: isTwitterLink(bookmark.link.url)
+            style: isTwitterLink(bookmark.url)
               ? BookmarkDigestStyle.TWEET_EMBED
               : BookmarkDigestStyle.BLOCK,
           });

--- a/src/components/bookmark/BookmarkItem.tsx
+++ b/src/components/bookmark/BookmarkItem.tsx
@@ -23,7 +23,7 @@ import { Tooltip } from '../Tooltip';
 import { DeletePopover, MultipleDeletePopover } from '../Popover';
 
 type Props = {
-  bookmarkedLink: TeamBookmarkedLinkItem;
+  teamLink: TeamBookmarkedLinkItem;
   teamSlug: string;
   teamId: string;
   digestId?: string;
@@ -61,7 +61,7 @@ export const getContributorsString = (
 };
 
 export const BookmarkItem = ({
-  bookmarkedLink,
+  teamLink,
   teamSlug,
   teamId,
   digestId,
@@ -70,7 +70,7 @@ export const BookmarkItem = ({
 }: Props) => {
   const { successToast, errorToast } = useCustomToast();
   const { isRefreshing, refresh } = useTransitionRefresh();
-  const bookmarksNumber = bookmarkedLink.bookmark?.length;
+  const bookmarksNumber = teamLink.bookmark?.length;
 
   const { mutate: deleteBookmark, isLoading: isDeleting } = useMutation<
     AxiosResponse<ApiBookmarkResponseSuccess>,
@@ -100,7 +100,7 @@ export const BookmarkItem = ({
 
   return (
     <div
-      key={bookmarkedLink?.id}
+      key={teamLink?.id}
       className={clsx(
         'group relative flex w-full rounded-md p-2 hover:bg-gray-50 flex-col',
         { 'opacity-60': isRefreshing }
@@ -125,16 +125,16 @@ export const BookmarkItem = ({
         <div className="flex gap-2 overflow-hidden w-[100%] justify-start">
           <div className="relative w-16 h-16 overflow-hidden rounded-md border max-w-[4rem]">
             <BookmarkImage
-              link={bookmarkedLink}
+              link={teamLink}
               fallbackSrc={`${getEnvHost()}/api/bookmark-og?bookmark=${
-                bookmarkedLink.id
+                teamLink.id
               }`}
             />
           </div>
           <div className="flex flex-col items-start max-w-[100%] overflow-hidden flex-1">
             <div className="flex flex-col overflow-hidden max-w-[100%]">
               <span className="truncate font-semibold whitespace-nowrap">
-                {bookmarkedLink.title || bookmarkedLink.url}
+                {teamLink.title || teamLink.url}
               </span>
 
               <div className="flex items-center text-sm text-gray-500">
@@ -148,26 +148,26 @@ export const BookmarkItem = ({
                       </div>
                     }
                   >
-                    {getContributorsString(bookmarkedLink.bookmark)}
+                    {getContributorsString(teamLink.bookmark)}
                   </Tooltip>
                 ) : (
                   <div className="whitespace-nowrap max-w-[33%] sm:max-w-none truncate">
-                    {getContributorsString(bookmarkedLink.bookmark)}
+                    {getContributorsString(teamLink.bookmark)}
                   </div>
                 )}
                 <div className="mx-1">-</div>
                 <div className="whitespace-nowrap max-w-[33%] sm:max-w-none truncate">
                   {editMode ? (
                     <Link
-                      href={bookmarkedLink.url}
+                      href={teamLink.url}
                       target="_blank"
                       className="text-gray-400 whitespace-nowrap overflow-hidden text-ellipsis underline underline-offset-2"
                     >
-                      {getDomainFromUrl(bookmarkedLink.url)}
+                      {getDomainFromUrl(teamLink.url)}
                     </Link>
                   ) : (
                     <span className="cursor-auto">
-                      {getDomainFromUrl(bookmarkedLink.url)}
+                      {getDomainFromUrl(teamLink.url)}
                     </span>
                   )}
                 </div>
@@ -176,14 +176,14 @@ export const BookmarkItem = ({
                   {bookmarksNumber > 1 ? (
                     <MultipleDeletePopover
                       onDelete={(bookmarkId) => deleteBookmark({ bookmarkId })}
-                      bookmarks={bookmarkedLink.bookmark}
+                      bookmarks={teamLink.bookmark}
                       isLoading={isLoading}
                     />
                   ) : (
                     <DeletePopover
                       handleDelete={() =>
                         deleteBookmark({
-                          bookmarkId: bookmarkedLink.bookmark[0]?.id,
+                          bookmarkId: teamLink.bookmark[0]?.id,
                         })
                       }
                       isLoading={isLoading}
@@ -192,16 +192,16 @@ export const BookmarkItem = ({
                 </div>
               </div>
             </div>
-            {bookmarkedLink.description && (
+            {teamLink.description && (
               <p className={clsx('pt-2 text-sm', { 'opacity-60': isUsed })}>
-                {bookmarkedLink.description}
+                {teamLink.description}
               </p>
             )}
           </div>
         </div>
         {editMode && digestId && (
           <BookmarkAddButton
-            bookmark={bookmarkedLink}
+            bookmark={teamLink}
             teamId={teamId}
             digestId={digestId}
           />

--- a/src/components/bookmark/BookmarkListDnd.tsx
+++ b/src/components/bookmark/BookmarkListDnd.tsx
@@ -1,18 +1,14 @@
-import { TeamBookmarkedLinks, getDigest, getTeamBySlug } from '@/lib/queries';
+import { TeamLinks, getDigest, getTeamBySlug } from '@/lib/queries';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import { BookmarkItem } from './BookmarkItem';
 
 export type BookmarkListDndProps = {
   digest: NonNullable<Awaited<ReturnType<typeof getDigest>>>;
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
-  bookmarkedLinks: TeamBookmarkedLinks;
+  teamLinks: TeamLinks;
 };
 
-const BookmarkListDnd = ({
-  bookmarkedLinks,
-  team,
-  digest,
-}: BookmarkListDndProps) => {
+const BookmarkListDnd = ({ teamLinks, team, digest }: BookmarkListDndProps) => {
   return (
     <Droppable droppableId="bookmark" type="bookmark">
       {(provided) => (
@@ -21,11 +17,11 @@ const BookmarkListDnd = ({
           {...provided.droppableProps}
           ref={provided.innerRef}
         >
-          {bookmarkedLinks?.map((bookmarkedLink, index) => {
+          {teamLinks?.map((teamLink, index) => {
             return (
               <Draggable
-                key={bookmarkedLink.id}
-                draggableId={bookmarkedLink.id}
+                key={teamLink.id}
+                draggableId={teamLink.id}
                 index={index}
               >
                 {(provided) => (
@@ -35,8 +31,8 @@ const BookmarkListDnd = ({
                     ref={provided.innerRef}
                   >
                     <BookmarkItem
-                      key={bookmarkedLink.id}
-                      bookmarkedLink={bookmarkedLink}
+                      key={teamLink.id}
+                      teamLink={teamLink}
                       teamSlug={team.slug}
                       teamId={team.id}
                       digestId={digest.id}

--- a/src/components/bookmark/BookmarkListDnd.tsx
+++ b/src/components/bookmark/BookmarkListDnd.tsx
@@ -21,7 +21,7 @@ const BookmarkListDnd = ({ teamLinks, team, digest }: BookmarkListDndProps) => {
             return (
               <Draggable
                 key={teamLink.id}
-                draggableId={teamLink.id}
+                draggableId={teamLink.bookmark[0].id}
                 index={index}
               >
                 {(provided) => (

--- a/src/components/bookmark/BookmarkListDnd.tsx
+++ b/src/components/bookmark/BookmarkListDnd.tsx
@@ -1,19 +1,18 @@
-import {
-  TeamBookmarksNotInDigestResult,
-  getDigest,
-  getTeamBookmarksNotInDigest,
-  getTeamBySlug,
-} from '@/lib/queries';
+import { TeamBookmarkedLinks, getDigest, getTeamBySlug } from '@/lib/queries';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import { BookmarkItem } from './BookmarkItem';
 
 export type BookmarkListDndProps = {
   digest: NonNullable<Awaited<ReturnType<typeof getDigest>>>;
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
-  bookmarks: TeamBookmarksNotInDigestResult['bookmarks'];
+  bookmarkedLinks: TeamBookmarkedLinks;
 };
 
-const BookmarkListDnd = ({ bookmarks, team, digest }: BookmarkListDndProps) => {
+const BookmarkListDnd = ({
+  bookmarkedLinks,
+  team,
+  digest,
+}: BookmarkListDndProps) => {
   return (
     <Droppable droppableId="bookmark" type="bookmark">
       {(provided) => (
@@ -22,11 +21,11 @@ const BookmarkListDnd = ({ bookmarks, team, digest }: BookmarkListDndProps) => {
           {...provided.droppableProps}
           ref={provided.innerRef}
         >
-          {bookmarks.map((bookmark, index) => {
+          {bookmarkedLinks?.map((bookmarkedLink, index) => {
             return (
               <Draggable
-                key={bookmark.id}
-                draggableId={bookmark.id}
+                key={bookmarkedLink.id}
+                draggableId={bookmarkedLink.id}
                 index={index}
               >
                 {(provided) => (
@@ -36,8 +35,8 @@ const BookmarkListDnd = ({ bookmarks, team, digest }: BookmarkListDndProps) => {
                     ref={provided.innerRef}
                   >
                     <BookmarkItem
-                      key={bookmark.id}
-                      bookmark={bookmark}
+                      key={bookmarkedLink.id}
+                      bookmarkedLink={bookmarkedLink}
                       teamSlug={team.slug}
                       teamId={team.id}
                       digestId={digest.id}

--- a/src/components/bookmark/BookmarksListControls.tsx
+++ b/src/components/bookmark/BookmarksListControls.tsx
@@ -34,7 +34,7 @@ export const BookmarksListControls = ({
     <div className="flex items-center justify-end gap-3 max-sm:w-full max-sm:justify-between">
       <Switch
         label="View all bookmarks"
-        onClick={handleCheckboxChange}
+        onChange={handleCheckboxChange}
         checked={searchParams?.has('all')}
       />
       <Pagination totalItems={linkCount} className="h-6" />

--- a/src/components/bookmark/BookmarksTeamList.tsx
+++ b/src/components/bookmark/BookmarksTeamList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TeamBookmarksResult } from '@/lib/queries';
+import { TeamBookmarkedLinks } from '@/lib/queries';
 import { BsFillBookmarkFill } from '@react-icons/all-files/bs/BsFillBookmarkFill';
 import NoContent from '../layout/NoContent';
 import { BookmarkItem } from './BookmarkItem';
@@ -8,16 +8,20 @@ import Link from 'next/link';
 import SearchInput from '../digests/SearchInput';
 
 type Props = {
-  bookmarks: TeamBookmarksResult[];
+  bookmarkedLinks: TeamBookmarkedLinks;
   teamId: string;
   teamSlug: string;
 };
 
-export const BookmarksTeamList = ({ bookmarks, teamId, teamSlug }: Props) => {
+export const BookmarksTeamList = ({
+  bookmarkedLinks,
+  teamId,
+  teamSlug,
+}: Props) => {
   return (
     <div className="w-full">
       <SearchInput className="mb-4" />
-      {bookmarks.length < 1 ? (
+      {bookmarkedLinks.length < 1 ? (
         <NoContent
           icon={<BsFillBookmarkFill />}
           title="No bookmark"
@@ -25,19 +29,25 @@ export const BookmarksTeamList = ({ bookmarks, teamId, teamSlug }: Props) => {
         />
       ) : (
         <div className="flex flex-col gap-2">
-          {bookmarks.map((bookmark) => (
+          {bookmarkedLinks?.map((bookmarkedLink) => (
             <Link
-              key={bookmark?.id}
-              href={bookmark.link.url}
+              key={bookmarkedLink?.id}
+              href={bookmarkedLink.url}
               target="_blank"
               rel="noopener noreferrer"
             >
               <BookmarkItem
-                bookmark={bookmark}
+                bookmarkedLink={bookmarkedLink}
                 teamSlug={teamSlug}
                 teamId={teamId}
-                digestId={bookmark.digestBlocks[0]?.digest.id}
-                nbOfTimesUsed={bookmark.digestBlocks.length}
+                digestId={
+                  bookmarkedLink.bookmark?.find(
+                    (bookmarkedLink) => bookmarkedLink?.digestBlocks?.length
+                  )?.digestBlocks[0].digest.id
+                }
+                isUsed={bookmarkedLink.bookmark?.some(
+                  (bookmarkedLink) => bookmarkedLink.digestBlocks.length
+                )}
               />
             </Link>
           ))}

--- a/src/components/bookmark/BookmarksTeamList.tsx
+++ b/src/components/bookmark/BookmarksTeamList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TeamBookmarkedLinks } from '@/lib/queries';
+import { TeamLinks } from '@/lib/queries';
 import { BsFillBookmarkFill } from '@react-icons/all-files/bs/BsFillBookmarkFill';
 import NoContent from '../layout/NoContent';
 import { BookmarkItem } from './BookmarkItem';
@@ -8,20 +8,16 @@ import Link from 'next/link';
 import SearchInput from '../digests/SearchInput';
 
 type Props = {
-  bookmarkedLinks: TeamBookmarkedLinks;
+  teamLinks: TeamLinks;
   teamId: string;
   teamSlug: string;
 };
 
-export const BookmarksTeamList = ({
-  bookmarkedLinks,
-  teamId,
-  teamSlug,
-}: Props) => {
+export const BookmarksTeamList = ({ teamLinks, teamId, teamSlug }: Props) => {
   return (
     <div className="w-full">
       <SearchInput className="mb-4" />
-      {bookmarkedLinks.length < 1 ? (
+      {teamLinks.length < 1 ? (
         <NoContent
           icon={<BsFillBookmarkFill />}
           title="No bookmark"
@@ -29,24 +25,24 @@ export const BookmarksTeamList = ({
         />
       ) : (
         <div className="flex flex-col gap-2">
-          {bookmarkedLinks?.map((bookmarkedLink) => (
+          {teamLinks?.map((teamLink) => (
             <Link
-              key={bookmarkedLink?.id}
-              href={bookmarkedLink.url}
+              key={teamLink?.id}
+              href={teamLink.url}
               target="_blank"
               rel="noopener noreferrer"
             >
               <BookmarkItem
-                bookmarkedLink={bookmarkedLink}
+                teamLink={teamLink}
                 teamSlug={teamSlug}
                 teamId={teamId}
                 digestId={
-                  bookmarkedLink.bookmark?.find(
-                    (bookmarkedLink) => bookmarkedLink?.digestBlocks?.length
+                  teamLink.bookmark?.find(
+                    (teamLink) => teamLink?.digestBlocks?.length
                   )?.digestBlocks[0].digest.id
                 }
-                isUsed={bookmarkedLink.bookmark?.some(
-                  (bookmarkedLink) => bookmarkedLink.digestBlocks.length
+                isUsed={teamLink.bookmark?.some(
+                  (teamLink) => teamLink.digestBlocks.length
                 )}
               />
             </Link>

--- a/src/components/bookmark/NewsBookmark.tsx
+++ b/src/components/bookmark/NewsBookmark.tsx
@@ -1,5 +1,5 @@
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
-import { TeamBookmarkedLinkItem, TeamBookmarkedLinks } from '@/lib/queries';
+import { TeamBookmarkedLinkItem, TeamLinks } from '@/lib/queries';
 import { PlusCircleIcon } from '@heroicons/react/24/solid';
 import { DigestBlockType } from '@prisma/client';
 import { AiOutlineLoading3Quarters as LoadingIcon } from '@react-icons/all-files/ai/AiOutlineLoading3Quarters';
@@ -8,11 +8,11 @@ import { PropsWithChildren } from 'react';
 import BookmarkImage from './BookmarkImage';
 
 export const Bookmark = ({
-  bookmarkedLink,
+  teamLink,
   teamId,
   digestId,
 }: {
-  bookmarkedLink: TeamBookmarkedLinkItem;
+  teamLink: TeamBookmarkedLinkItem;
   teamId: string;
   digestId: string;
 } & PropsWithChildren) => {
@@ -25,19 +25,19 @@ export const Bookmark = ({
       <div className="flex w-full justify-between">
         <div className="flex gap-2 overflow-hidden w-[100%] justify-start">
           <div className="relative w-16 h-16 overflow-hidden rounded-md border max-w-[4rem]">
-            <BookmarkImage link={bookmarkedLink} />
+            <BookmarkImage link={teamLink} />
           </div>
           <div className="flex flex-col items-start max-w-[100%] overflow-hidden flex-1">
             <div className="flex flex-col overflow-hidden max-w-[100%]">
               <p className="font-semibold whitespace-nowrap overflow-hidden text-ellipsis text-base text-gray-800">
-                {bookmarkedLink.title}
+                {teamLink.title}
               </p>
               <Link
-                href={bookmarkedLink.url}
+                href={teamLink.url}
                 target="_blank"
                 className="text-gray-400 whitespace-nowrap overflow-hidden text-ellipsis text-base underline underline-offset-2"
               >
-                {bookmarkedLink.url}
+                {teamLink.url}
               </Link>
             </div>
           </div>
@@ -49,7 +49,7 @@ export const Bookmark = ({
             onClick={(e) => {
               e.preventDefault();
               add.mutate({
-                bookmarkId: bookmarkedLink.id,
+                bookmarkId: teamLink.id,
                 type: DigestBlockType.BOOKMARK,
               });
             }}

--- a/src/components/pages/DigestEditPage.tsx
+++ b/src/components/pages/DigestEditPage.tsx
@@ -8,9 +8,9 @@ import api from '@/lib/api';
 
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
 import {
-  TeamBookmarksNotInDigestResult,
+  TeamBookmarkedLinks,
+  TeamBookmarkedLinksData,
   getDigest,
-  getTeamBookmarksNotInDigest,
   getTeamBySlug,
 } from '@/lib/queries';
 import { ApiDigestResponseSuccess } from '@/pages/api/teams/[teamId]/digests';
@@ -44,7 +44,7 @@ import DigestEditTypefully from './DigestEditTypefully';
 import DigestEditSendNewsletter from './DigestEditSendNewsletter';
 
 type Props = {
-  dataBookmarks: TeamBookmarksNotInDigestResult;
+  bookmarkedLinksData: TeamBookmarkedLinksData;
   digest: NonNullable<Awaited<ReturnType<typeof getDigest>>>;
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
 };
@@ -57,7 +57,7 @@ type DigestData = {
 };
 
 export const DigestEditPage = ({
-  dataBookmarks: { totalCount, bookmarks, itemPerPage },
+  bookmarkedLinksData: { totalCount, bookmarkedLinks, perPage },
   digest,
   team,
 }: Props) => {
@@ -271,16 +271,16 @@ export const DigestEditPage = ({
             <SectionContainer title="Bookmarks" className="relative">
               <Pagination
                 totalItems={totalCount}
-                itemsPerPage={itemPerPage}
+                itemsPerPage={perPage}
                 className="absolute top-5 right-5"
               />
               <SearchInput className="mb-4" />
               <div className="flex flex-col gap-2">
-                {bookmarks && bookmarks.length > 0 ? (
+                {bookmarkedLinks && bookmarkedLinks.length > 0 ? (
                   <BookmarkListDnd
                     team={team}
                     digest={digest}
-                    bookmarks={bookmarks}
+                    bookmarkedLinks={bookmarkedLinks}
                   />
                 ) : (
                   <NoContent
@@ -291,10 +291,7 @@ export const DigestEditPage = ({
                 )}
               </div>
               <div className="flex justify-end">
-                <Pagination
-                  totalItems={totalCount}
-                  itemsPerPage={itemPerPage}
-                />
+                <Pagination totalItems={totalCount} itemsPerPage={perPage} />
               </div>
             </SectionContainer>
           </div>

--- a/src/components/pages/DigestEditPage.tsx
+++ b/src/components/pages/DigestEditPage.tsx
@@ -8,8 +8,8 @@ import api from '@/lib/api';
 
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
 import {
-  TeamBookmarkedLinks,
-  TeamBookmarkedLinksData,
+  TeamLinks,
+  TeamLinksData,
   getDigest,
   getTeamBySlug,
 } from '@/lib/queries';
@@ -44,7 +44,7 @@ import DigestEditTypefully from './DigestEditTypefully';
 import DigestEditSendNewsletter from './DigestEditSendNewsletter';
 
 type Props = {
-  bookmarkedLinksData: TeamBookmarkedLinksData;
+  teamLinksData: TeamLinksData;
   digest: NonNullable<Awaited<ReturnType<typeof getDigest>>>;
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
 };
@@ -57,7 +57,7 @@ type DigestData = {
 };
 
 export const DigestEditPage = ({
-  bookmarkedLinksData: { totalCount, bookmarkedLinks, perPage },
+  teamLinksData: { totalCount, teamLinks, perPage },
   digest,
   team,
 }: Props) => {
@@ -276,11 +276,11 @@ export const DigestEditPage = ({
               />
               <SearchInput className="mb-4" />
               <div className="flex flex-col gap-2">
-                {bookmarkedLinks && bookmarkedLinks.length > 0 ? (
+                {teamLinks && teamLinks.length > 0 ? (
                   <BookmarkListDnd
                     team={team}
                     digest={digest}
-                    bookmarkedLinks={bookmarkedLinks}
+                    teamLinks={teamLinks}
                   />
                 ) : (
                   <NoContent

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -1,7 +1,7 @@
 'use client';
 import {
   getTeamBySlug,
-  TeamBookmarksResult,
+  TeamBookmarkedLinks,
   TeamDigestsResult,
 } from '@/lib/queries';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
@@ -19,13 +19,13 @@ import { BsFillBookmarkFill } from '@react-icons/all-files/bs/BsFillBookmarkFill
 
 type Props = {
   linkCount: number;
-  bookmarks: TeamBookmarksResult[];
+  bookmarkedLinks: TeamBookmarkedLinks;
   digests: TeamDigestsResult[];
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
   search?: string;
 };
 
-const Team = ({ team, linkCount, bookmarks, digests, search }: Props) => {
+const Team = ({ team, linkCount, bookmarkedLinks, digests, search }: Props) => {
   return (
     <PageContainer title={team.name}>
       <div className="flex max-lg:flex-col gap-5 pb-4">
@@ -46,7 +46,7 @@ const Team = ({ team, linkCount, bookmarks, digests, search }: Props) => {
             </div>
           }
         >
-          {!search && !bookmarks?.length ? (
+          {!search && !bookmarkedLinks?.length ? (
             <NoContent
               icon={<BsFillBookmarkFill />}
               title="No bookmark"
@@ -56,7 +56,7 @@ const Team = ({ team, linkCount, bookmarks, digests, search }: Props) => {
             <BookmarksTeamList
               teamId={team.id}
               teamSlug={team.slug}
-              bookmarks={bookmarks}
+              bookmarkedLinks={bookmarkedLinks}
             />
           )}
         </Card>

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -1,9 +1,5 @@
 'use client';
-import {
-  getTeamBySlug,
-  TeamBookmarkedLinks,
-  TeamDigestsResult,
-} from '@/lib/queries';
+import { getTeamBySlug, TeamLinks, TeamDigestsResult } from '@/lib/queries';
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
 import { BookmarksTeamList } from '../bookmark/BookmarksTeamList';
@@ -19,13 +15,13 @@ import { BsFillBookmarkFill } from '@react-icons/all-files/bs/BsFillBookmarkFill
 
 type Props = {
   linkCount: number;
-  bookmarkedLinks: TeamBookmarkedLinks;
+  teamLinks: TeamLinks;
   digests: TeamDigestsResult[];
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
   search?: string;
 };
 
-const Team = ({ team, linkCount, bookmarkedLinks, digests, search }: Props) => {
+const Team = ({ team, linkCount, teamLinks, digests, search }: Props) => {
   return (
     <PageContainer title={team.name}>
       <div className="flex max-lg:flex-col gap-5 pb-4">
@@ -46,7 +42,7 @@ const Team = ({ team, linkCount, bookmarkedLinks, digests, search }: Props) => {
             </div>
           }
         >
-          {!search && !bookmarkedLinks?.length ? (
+          {!search && !teamLinks?.length ? (
             <NoContent
               icon={<BsFillBookmarkFill />}
               title="No bookmark"
@@ -56,7 +52,7 @@ const Team = ({ team, linkCount, bookmarkedLinks, digests, search }: Props) => {
             <BookmarksTeamList
               teamId={team.id}
               teamSlug={team.slug}
-              bookmarkedLinks={bookmarkedLinks}
+              teamLinks={teamLinks}
             />
           )}
         </Card>

--- a/src/emails/templates/NewsletterEmail.tsx
+++ b/src/emails/templates/NewsletterEmail.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import { remark } from 'remark';
 import html from 'remark-html';
 
-const Bookmark = ({
+const NewsBookmark = ({
   bookmark,
 }: {
   bookmark: NewsletterBookmark;
@@ -151,7 +151,7 @@ const NewsletterEmail = ({
         {blocks?.length &&
           blocks.map((block, i) => {
             if (block.type === BlockType.BOOKMARK) {
-              return <Bookmark bookmark={block} key={i} />;
+              return <NewsBookmark bookmark={block} key={i} />;
             } else if (block.type === BlockType.TEXT) {
               return <Text text={block.text} key={i} />;
             }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -142,7 +142,7 @@ export const getTeamInvitations = (slug: string) =>
 /**
  * Get bookmarks of a team in the team page, used to list the bookmarks in the team page
  */
-export const getTeamBookmarkedLinks = async (
+export const getTeamLinks = async (
   teamId: string,
   options: {
     page?: number;
@@ -192,7 +192,7 @@ export const getTeamBookmarkedLinks = async (
     where,
   });
 
-  const bookmarkedLinks = await db.link.findMany({
+  const teamLinks = await db.link.findMany({
     take: perPage,
     skip: page ? (page - 1) * perPage : 0,
     orderBy: {
@@ -238,19 +238,17 @@ export const getTeamBookmarkedLinks = async (
   });
 
   return {
-    bookmarkedLinks: bookmarkedLinks,
+    teamLinks,
     totalCount,
     perPage,
   };
 };
 
-export type TeamBookmarkedLinksData = Awaited<
-  ReturnType<typeof getTeamBookmarkedLinks>
->;
+export type TeamLinksData = Awaited<ReturnType<typeof getTeamLinks>>;
 
-export type TeamBookmarkedLinks = TeamBookmarkedLinksData['bookmarkedLinks'];
+export type TeamLinks = TeamLinksData['teamLinks'];
 
-export type TeamBookmarkedLinkItem = TeamBookmarkedLinks[number];
+export type TeamBookmarkedLinkItem = TeamLinks[number];
 
 export const getTeamDigests = async (
   teamId: string,

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -153,35 +153,39 @@ export const getTeamBookmarkedLinks = async (
 ) => {
   const { page, perPage = 10 } = options;
 
-  const where = {
-    bookmark: {
-      some: {
-        teamId,
-      },
-      ...(options.onlyNotInDigest && {
-        every: {
-          digestBlocks: { none: {} },
+  const searchWhere = {
+    OR: [
+      {
+        title: {
+          contains: options.search,
+          mode: Prisma.QueryMode.insensitive,
         },
-      }),
-    },
-    ...(options.search && {
-      link: {
-        OR: [
-          {
-            title: {
-              contains: options.search,
-              mode: 'insensitive',
-            },
-          },
-          {
-            description: {
-              contains: options.search,
-              mode: 'insensitive',
-            },
-          },
-        ],
       },
-    }),
+      {
+        description: {
+          contains: options.search,
+          mode: Prisma.QueryMode.insensitive,
+        },
+      },
+    ],
+  };
+
+  const where = {
+    AND: [
+      options.search ? searchWhere : {},
+      {
+        bookmark: {
+          some: {
+            teamId,
+          },
+          ...(options.onlyNotInDigest && {
+            every: {
+              digestBlocks: { none: {} },
+            },
+          }),
+        },
+      },
+    ],
   };
 
   const totalCount = await db.link.count({

--- a/src/messages/en.ts
+++ b/src/messages/en.ts
@@ -280,7 +280,14 @@ const message = {
   },
   bookmark: {
     delete: {
-      success: 'Your link has been deleted',
+      success: 'Your bookmark has been deleted',
+    },
+    create: {
+      error: {
+        already_bookmarked:
+          'You have already bookmarked this link in this team',
+        invalid_link: 'Invalid link provided',
+      },
     },
   },
   team: {

--- a/src/pages/api/bookmark/index.ts
+++ b/src/pages/api/bookmark/index.ts
@@ -39,7 +39,7 @@ router.post(async (req, res) => {
       return res.status(201).json(bookmark);
     } catch (error: unknown) {
       Sentry.captureException(error);
-
+      console.log(error);
       return res.status(400).json({
         error: 'Invalid link',
       });

--- a/src/utils/bookmark.ts
+++ b/src/utils/bookmark.ts
@@ -31,6 +31,36 @@ const getHtml = async (url: string) => {
   });
 };
 
+const isBookmarkedByUser = async (
+  linkId?: string,
+  membershipId?: string,
+  teamId?: string
+) => {
+  if (!linkId || !membershipId || !teamId) return;
+
+  return db.bookmark
+    .findFirst({
+      select: { id: true },
+      where: {
+        linkId: {
+          equals: linkId,
+        },
+        membershipId: {
+          equals: membershipId,
+        },
+        teamId: {
+          equals: teamId,
+        },
+      },
+    })
+    .then((response) => {
+      console.log(response);
+      if (response?.id) {
+        throw new TypeError('already_bookmarked');
+      }
+    });
+};
+
 export const extractMetadata = async (url: string) => {
   const html = await getHtml(url);
   const metadata = (await metascraper({
@@ -65,7 +95,10 @@ export const saveBookmark = async (
       },
     },
   });
+
   await isLinkValid(linkUrl);
+  await isBookmarkedByUser(link?.id, membershipId, teamId);
+
   if (!link) {
     const metadata = await extractMetadata(linkUrl);
 


### PR DESCRIPTION
**Issue**
https://github.com/premieroctet/digestclub/issues/7

**Description**
- Keep only 1 call for listing in Team (getTeamBookmarksNotInDigest was not required as getTeamBookmarks enabled args to get only bookmarks not in digests)

**Screenshot**
Delete button for link bookmarked several times by team users
![image](https://github.com/premieroctet/digestclub/assets/25606391/ee264eb7-13d9-417e-a373-7e42e86bde82)


Delete button for link bookmarked one time by team users
![image](https://github.com/premieroctet/digestclub/assets/25606391/46b0e892-d709-44bc-abb7-95b68afe7872)


Links bookmarked several times we display a tooltip with names and date of users bookmarking actions
![image](https://github.com/premieroctet/digestclub/assets/25606391/5f3afa28-f01e-4552-99c9-8fe921bb9f9c)

User cannot add several same link in same team several times
![image](https://github.com/premieroctet/digestclub/assets/25606391/de21869d-408c-4817-ae32-8ee38a8ae25e)

