### PR TITLE
merge fix/update-twitter-link-utils-with-x-domain-name to main

### DIFF
--- a/src/utils/link/index.test.js
+++ b/src/utils/link/index.test.js
@@ -29,6 +29,20 @@ describe('isTwitterLink', () => {
     const result = isTwitterLink(link);
     expect(result).toBe(expected);
   });
+
+  test('url to X domain tweet should return true', () => {
+    const link = 'https://x.com/dan_abramov/status/1705952101845668101?s=20';
+    const expected = true;
+    const result = isTwitterLink(link);
+    expect(result).toBe(expected);
+  });
+
+  test('url to X domain user should return true', () => {
+    const link = 'https://x.com/mattpocockuk';
+    const expected = true;
+    const result = isTwitterLink(link);
+    expect(result).toBe(expected);
+  });
 });
 
 describe('getTweetId', () => {
@@ -39,9 +53,23 @@ describe('getTweetId', () => {
     expect(result).toBe(expected);
   });
 
+  test('url to user (X domain) should return false', () => {
+    const link = 'https://x.com/mattpocockuk';
+    const expected = false;
+    const result = getTweetId(link);
+    expect(result).toBe(expected);
+  });
+
   test('url to tweet should return true', () => {
     const link = 'https://twitter.com/AdamRackis/status/1376920000000000000';
     const expected = '1376920000000000000';
+    const result = getTweetId(link);
+    expect(result).toBe(expected);
+  });
+
+  test('url to tweet (X domain) should return true', () => {
+    const link = 'https://x.com/dan_abramov/status/1705952101845668101?s=20';
+    const expected = '1705952101845668101';
     const result = getTweetId(link);
     expect(result).toBe(expected);
   });
@@ -58,6 +86,20 @@ describe('getTweetId', () => {
     expect(result2).toBe(expected);
     expect(result3).toBe(expected);
   });
+
+  test('url to status without status should return false (X domain)', () => {
+    const link1 = 'https://x.com/AdamRackis/status/';
+    const link2 = 'https://x.com/AdamRackis/1319672639921807361';
+    const link3 = 'https://x.com/AdamRackis/status';
+    const expected = false;
+    const result1 = getTweetId(link1);
+    const result2 = getTweetId(link2);
+    const result3 = getTweetId(link3);
+    expect(result1).toBe(expected);
+    expect(result2).toBe(expected);
+    expect(result3).toBe(expected);
+  });
+
   test('url to google.com should return false', () => {
     const link = 'https://www.google.com';
     const expected = false;

--- a/src/utils/link/index.ts
+++ b/src/utils/link/index.ts
@@ -21,7 +21,8 @@ export async function isLinkValid(url: string): Promise<boolean> {
  * @returns a boolean indicating if the URL is a twitter link
  */
 export function isTwitterLink(url: string): boolean {
-  const twitterPattern = /^https?:\/\/(?:www\.)?twitter\.com\/.*$/;
+  const twitterPattern =
+    /^(?:https?:\/\/(?:www\.)?)?(?:twitter\.com|x\.com)\/.*$/;
 
   return twitterPattern.test(url);
 }
@@ -33,15 +34,13 @@ export function isTwitterLink(url: string): boolean {
  * @returns false if the URL is not a valid tweet link
  */
 export function getTweetId(url: string): false | string {
-  const twitterPattern = /^https?:\/\/(?:www\.)?twitter\.com\/.*\/status\/.*$/;
+  const twitterPattern =
+    /^(?:https?:\/\/(?:www\.)?)?(?:twitter\.com|x\.com)\/.*\/status\/(\d+)(?:\?.*)?$/;
 
-  if (twitterPattern.test(url)) {
-    const urlParts = url.split('/');
-    const id = urlParts[urlParts.length - 1];
-    if (id === '') {
-      return false;
-    }
-    return id;
+  const match = url.match(twitterPattern);
+
+  if (match && match[1]) {
+    return match[1];
   } else {
     return false;
   }


### PR DESCRIPTION
Twitter links were not functioning correctly when the domain name 'x' was used. I have updated the utility functions and included new tests to accommodate the 'x' domain name.