### PR TITLE
merge 29-make-the-public-digest-page-more-compact-and-easier-to-read into main

### DIFF
--- a/src/components/digests/BlockListDnd.tsx
+++ b/src/components/digests/BlockListDnd.tsx
@@ -37,7 +37,7 @@ export const BlockListDnd = ({ digest }: BlockListDndProps) => {
                         ref={provided.innerRef}
                         className="group relative flex flex-col w-full will-change-transform bg-white rounded-md"
                       >
-                        <BlockCard block={block} isEditable />
+                        <BlockCard block={block} isEditable index={index} />
                       </li>
                     )}
                   </Draggable>

--- a/src/components/digests/PublicDigestList.tsx
+++ b/src/components/digests/PublicDigestList.tsx
@@ -48,7 +48,7 @@ export default function PublicDigestList({ digest }: Props) {
           </div>
         </div>
       </div>
-      <div className="mt-2 px-0 md:px-10 py-2 md:pb-8 w-full space-y-8">
+      <div className="mt-2 px-0 md:px-10 py-2 md:pb-8 w-full space-y-5">
         {digest.digestBlocks.length === 0 ? (
           <NoContent
             icon={<BookmarkIcon className="h-8 w-8" />}
@@ -57,7 +57,7 @@ export default function PublicDigestList({ digest }: Props) {
           />
         ) : (
           digest.digestBlocks.map((block, i) => {
-            return <BlockCard key={i} block={block} />;
+            return <BlockCard key={i} block={block} index={i} />;
           })
         )}
       </div>

--- a/src/components/digests/PublicDigestList.tsx
+++ b/src/components/digests/PublicDigestList.tsx
@@ -48,7 +48,7 @@ export default function PublicDigestList({ digest }: Props) {
           </div>
         </div>
       </div>
-      <div className="mt-2 px-0 md:px-10 py-2 md:pb-8 w-full space-y-5">
+      <div className="mt-2 px-0 md:px-10 py-2 md:pb-8 w-full space-y-4">
         {digest.digestBlocks.length === 0 ? (
           <NoContent
             icon={<BookmarkIcon className="h-8 w-8" />}

--- a/src/components/digests/block-card/BlockCard.tsx
+++ b/src/components/digests/block-card/BlockCard.tsx
@@ -7,13 +7,14 @@ import BookmarkCard from './bookmark-card/BookmarkCard';
 export interface Props {
   block: PublicDigestListProps['digest']['digestBlocks'][number];
   isEditable?: boolean;
+  index?: number;
 }
 
-export default function BlockCard({ block, isEditable = false }: Props) {
+export default function BlockCard({ block, isEditable = false, index }: Props) {
   if (block.type === DigestBlockType.TEXT) {
-    return <TextCard block={block} isEditable={isEditable} />;
+    return <TextCard block={block} isEditable={isEditable} index={index} />;
   } else if (block.type === DigestBlockType.BOOKMARK) {
-    return <BookmarkCard block={block} isEditable={isEditable} />;
+    return <BookmarkCard block={block} isEditable={isEditable} index={index} />;
   }
   throw new Error('BookmarkCard: bookmarkDigest has neither bookmark nor text');
 }

--- a/src/components/digests/block-card/bookmark-card/BookmarkCard.tsx
+++ b/src/components/digests/block-card/bookmark-card/BookmarkCard.tsx
@@ -16,11 +16,13 @@ export interface Props {
   isEditable?: boolean;
   remove?: () => void;
   isRemoving?: boolean;
+  index?: number;
 }
 
 export default function BlockBookmarkCard({
   block,
   isEditable = false,
+  index,
 }: Props) {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 

--- a/src/components/digests/block-card/text-card/TextCard.tsx
+++ b/src/components/digests/block-card/text-card/TextCard.tsx
@@ -50,7 +50,7 @@ export default function BlockTextCard({
           {Boolean(block.text) && (
             <div
               className={cn(
-                'prose prose-violet prose-sm prose-headings:mb-2 prose-p:mt-1 prose-p:leading-relaxed',
+                'prose prose-violet prose-sm prose-headings:mb-1 prose-headings:mt-3 prose-p:mt-1 prose-p:leading-relaxed',
                 {
                   'first:prose-h1:mt-7': index !== 0 && !isEditable,
                 }

--- a/src/components/digests/block-card/text-card/TextCard.tsx
+++ b/src/components/digests/block-card/text-card/TextCard.tsx
@@ -9,13 +9,18 @@ import { useParams } from 'next/navigation';
 import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
 import ActionsBlockPopover from '../../ActionsBlockPopover';
 import EditTextBlockDialog from '../../dialog/EditTextBlockDialog';
-
+import cn from 'classnames';
 export interface Props {
   block: PublicDigestListProps['digest']['digestBlocks'][number];
   isEditable?: boolean;
+  index?: number;
 }
 
-export default function BlockTextCard({ block, isEditable = false }: Props) {
+export default function BlockTextCard({
+  block,
+  isEditable = false,
+  index,
+}: Props) {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const { id: teamId } = useTeam();
   const params = useParams();
@@ -44,7 +49,12 @@ export default function BlockTextCard({ block, isEditable = false }: Props) {
           )}
           {Boolean(block.text) && (
             <div
-              className="prose prose-violet prose-sm"
+              className={cn(
+                'prose prose-violet prose-sm prose-headings:mb-2 prose-p:mt-1 prose-p:leading-relaxed',
+                {
+                  'first:prose-h1:mt-5': index !== 0 && !isEditable,
+                }
+              )}
               dangerouslySetInnerHTML={{
                 __html: htmlContent.toString(),
               }}

--- a/src/components/digests/block-card/text-card/TextCard.tsx
+++ b/src/components/digests/block-card/text-card/TextCard.tsx
@@ -52,7 +52,7 @@ export default function BlockTextCard({
               className={cn(
                 'prose prose-violet prose-sm prose-headings:mb-2 prose-p:mt-1 prose-p:leading-relaxed',
                 {
-                  'first:prose-h1:mt-5': index !== 0 && !isEditable,
+                  'first:prose-h1:mt-7': index !== 0 && !isEditable,
                 }
               )}
               dangerouslySetInnerHTML={{


### PR DESCRIPTION
Closes #29 
- Reduce gaps between blocks
- Add margin-top to `<h1>` except when the `<h1>` is the first block and the first child of the page
- Slightly reduce line-height in all markdown blocks
- Reduce all headings margin-bottom