### PR TITLE
Fix issue in text block overflow

### DIFF
--- a/src/components/digests/ActionsBlockPopover.tsx
+++ b/src/components/digests/ActionsBlockPopover.tsx
@@ -22,9 +22,9 @@ export default function ActionsBlockPopover({
   }
   return (
     <Popover.Root open={open} onOpenChange={() => setOpen(!open)}>
-      <div className="flex justify-center items-center gap-2 w-5 h-5 top-2 right-1 absolute md:relative cursor-pointer">
+      <div className="flex justify-center items-center gap-2 top-2 right-1 absolute md:relative cursor-pointer">
         <Popover.Trigger asChild className="relative">
-          <EllipsisVerticalIcon className="max-md:fill-white max-md:isolate" />
+          <EllipsisVerticalIcon className="max-md:fill-white max-md:isolate w-5 h-5 " />
         </Popover.Trigger>
         <Popover.Portal>
           <Popover.Content>

--- a/src/components/digests/block-card/text-card/TextCard.tsx
+++ b/src/components/digests/block-card/text-card/TextCard.tsx
@@ -50,7 +50,7 @@ export default function BlockTextCard({
           {Boolean(block.text) && (
             <div
               className={cn(
-                'prose prose-violet prose-sm prose-headings:mb-1 prose-headings:mt-3 prose-p:mt-1 prose-p:leading-relaxed',
+                'prose prose-violet prose-sm prose-headings:mb-1 prose-headings:mt-3 prose-p:mt-1 prose-p:leading-relaxed word break-all',
                 {
                   'first:prose-h1:mt-7': index !== 0 && !isEditable,
                 }


### PR DESCRIPTION
**Issue**
https://github.com/premieroctet/digestclub/issues/33

**Description**
- Fix text block without space overflowing in digest block list
- Fix issue of block text options icon smaller on markdown blocks

**Screenshot**
![image](https://github.com/premieroctet/digestclub/assets/25606391/1e0addc3-9f9d-42ed-b11b-b26205034b5b)
