### PR TITLE
Add template for digests

### DIFF
--- a/prisma/json-schema/json-schema.json
+++ b/prisma/json-schema/json-schema.json
@@ -537,6 +537,10 @@
         "isFeatured": {
           "type": "boolean",
           "default": false
+        },
+        "isTemplate": {
+          "type": "boolean",
+          "default": false
         }
       }
     },
@@ -596,6 +600,10 @@
             "string",
             "null"
           ]
+        },
+        "isTemplate": {
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/prisma/migrations/20231003092620_add_digest_template/migration.sql
+++ b/prisma/migrations/20231003092620_add_digest_template/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "digests" ADD COLUMN     "isTemplate" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20231005083313_digestblock_istemplate/migration.sql
+++ b/prisma/migrations/20231005083313_digestblock_istemplate/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "digest_blocks" ADD COLUMN     "isTemplate" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,6 +194,7 @@ model Digest {
   typefullyThreadUrl String?
   hasSentNewsletter Boolean @default(false)
   isFeatured Boolean @default(false)
+  isTemplate Boolean @default(false)
   
   @@unique([slug, teamId])
   @@map("digests")
@@ -212,6 +213,7 @@ model DigestBlock {
   description String?
   type        DigestBlockType @default(BOOKMARK)
   text        String?
+  isTemplate Boolean @default(false)
 
   @@unique([bookmarkId, digestId])
   @@map("digest_blocks")

--- a/src/app/(routes)/teams/[teamSlug]/digests/[digestId]/edit/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/digests/[digestId]/edit/page.tsx
@@ -1,3 +1,4 @@
+import { TemplateEdit } from '@/components/digests/templates/TemplateEdit';
 import { DigestEditPage } from '@/components/pages/DigestEditPage';
 import { TeamProvider } from '@/contexts/TeamContext';
 import {
@@ -40,11 +41,15 @@ const page = async ({ params, searchParams }: TeamPageProps) => {
 
   return (
     <TeamProvider team={team}>
-      <DigestEditPage
-        teamLinksData={teamLinksData}
-        digest={digest}
-        team={team}
-      />
+      {digest?.isTemplate ? (
+        <TemplateEdit template={digest} team={team} />
+      ) : (
+        <DigestEditPage
+          teamLinksData={teamLinksData}
+          digest={digest}
+          team={team}
+        />
+      )}
     </TeamProvider>
   );
 };

--- a/src/app/(routes)/teams/[teamSlug]/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/page.tsx
@@ -51,7 +51,7 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
     digestsPage,
     8
   );
-  const { digests: templates } = await getTeamDigests(team.id, 1, 11, true);
+  const { digests: templates } = await getTeamDigests(team.id, 1, 30, true);
 
   return (
     <Team

--- a/src/app/(routes)/teams/[teamSlug]/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/page.tsx
@@ -51,6 +51,7 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
     digestsPage,
     8
   );
+  const { digests: templates } = await getTeamDigests(team.id, 1, 11, true);
 
   return (
     <Team
@@ -60,6 +61,7 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
       digests={digests}
       digestsCount={digestsCount}
       search={search}
+      templates={templates}
     />
   );
 };

--- a/src/app/(routes)/teams/[teamSlug]/settings/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/settings/page.tsx
@@ -1,6 +1,7 @@
 import { TeamSettings } from '@/components/teams/TeamSettings';
 import {
   checkUserTeamBySlug,
+  getTeamDigests,
   getTeamInvitations,
   getTeamMembers,
   getTeamSubscriptions,
@@ -26,6 +27,7 @@ const TeamSettingsPage = async ({ params }: TeamPageProps) => {
   const members = await getTeamMembers(teamSlug);
   const invitations = await getTeamInvitations(teamSlug);
   const subscriptions = await getTeamSubscriptions(teamSlug);
+  const { digests: templates } = await getTeamDigests(team.id, 1, 30, true);
 
   if (!user?.id) return notFound();
   return (
@@ -35,6 +37,7 @@ const TeamSettingsPage = async ({ params }: TeamPageProps) => {
       invitations={invitations}
       user={user}
       subscriptions={subscriptions}
+      templates={templates}
     />
   );
 };

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -24,6 +24,7 @@ const buttonVariants = cva(
           'bg-transparent text-violet-700 ring-1 ring-transparent hover:bg-violet-100 hover:ring-violet-100',
         destructiveGhost:
           'bg-transparent text-red-700 ring-1 ring-transparent hover:bg-red-100 hover:ring-red-100',
+        link: 'ring-0 text-gray-700 text-sm underline hover:text-gray-400 font-light !px-0 !font-normal',
       },
       size: {
         sm: 'py-1 px-4 text-sm',

--- a/src/components/digests/DigestCreateInput.tsx
+++ b/src/components/digests/DigestCreateInput.tsx
@@ -5,44 +5,54 @@ import useTransitionRefresh from '@/hooks/useTransitionRefresh';
 import api from '@/lib/api';
 import { ApiDigestResponseSuccess } from '@/pages/api/teams/[teamId]/digests';
 import { AxiosError, AxiosResponse } from 'axios';
-import { ChangeEvent, useState } from 'react';
+import { FormEvent } from 'react';
 import { useMutation } from 'react-query';
 import { routes } from '@/core/constants';
 import { useRouter } from 'next/navigation';
 import clsx from 'clsx';
 import Button from '../Button';
-import { Input } from '../Input';
+import { Input, Select } from '../Input';
+import { TeamDigestsResult } from '@/lib/queries';
+import { Team } from '@prisma/client';
+import { formatTemplateTitle } from './templates/TemplateItem';
+import { useForm } from 'react-hook-form';
 
 type Props = {
-  teamId: string;
-  teamSlug: string;
+  team: Team;
   predictedDigestTitle: string | null;
+  templates?: TeamDigestsResult[];
 };
 
 export const DigestCreateInput = ({
-  teamId,
-  teamSlug,
+  team,
   predictedDigestTitle,
+  templates,
 }: Props) => {
   const router = useRouter();
   const { successToast, errorToast } = useCustomToast();
-  const [newDigestTiltle, setNewDigestTitle] = useState(
-    predictedDigestTitle ?? ''
-  );
   const { isRefreshing, refresh } = useTransitionRefresh();
+  const methods = useForm<{ title: string; templateId?: string }>({
+    mode: 'onBlur',
+    defaultValues: {
+      title: predictedDigestTitle ?? '',
+      templateId: undefined,
+    },
+  });
+  const { handleSubmit, register, watch } = methods;
 
   const { mutate: createDigest, isLoading } = useMutation<
     AxiosResponse<ApiDigestResponseSuccess>,
     AxiosError<ErrorResponse>,
-    string
+    { title: string; templateId?: string }
   >(
     'create-digest',
-    (title: string) => api.post(`/teams/${teamId}/digests`, { title }),
+    ({ title, templateId }) =>
+      api.post(`/teams/${team.id}/digests`, { title, templateId }),
     {
       onSuccess: (response) => {
         const newDigest = response.data;
         successToast('Your digest has been created!');
-        const route = routes.DIGEST_EDIT.replace(':slug', teamSlug).replace(
+        const route = routes.DIGEST_EDIT.replace(':slug', team.slug).replace(
           ':id',
           newDigest.id
         );
@@ -59,33 +69,53 @@ export const DigestCreateInput = ({
     }
   );
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (newDigestTiltle) {
-      createDigest(newDigestTiltle);
-    }
+  const onSubmit = (e: FormEvent) => {
+    handleSubmit((values) => {
+      createDigest(values);
+    })(e);
   };
+
+  const hasTemplates = !!templates?.length;
+  const title = watch('title');
+  const templateId = watch('templateId');
 
   return (
     <div>
       <form
-        onSubmit={handleSubmit}
-        className={clsx('w-full flex', isRefreshing && 'opacity-80')}
+        onSubmit={onSubmit}
+        className={clsx(
+          'w-full flex',
+          isRefreshing && 'opacity-80',
+          hasTemplates && 'flex-col gap-4'
+        )}
       >
-        <Input
-          className="px-4 rounded-r-none"
-          type="text"
-          placeholder="Digest name"
-          value={newDigestTiltle}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setNewDigestTitle(e.target.value)
-          }
-          required
-        />
+        <div className={clsx('flex-col flex w-full', hasTemplates && 'gap-2')}>
+          <Input
+            className={clsx('px-4', !hasTemplates && 'rounded-r-none')}
+            type="text"
+            placeholder="Digest name"
+            required
+            {...register('title')}
+          />
+          {hasTemplates && (
+            <Select
+              options={[
+                ...templates?.map((template) => ({
+                  value: template?.id,
+                  label: formatTemplateTitle(template?.title, team.slug),
+                })),
+              ]}
+              {...register('templateId')}
+            />
+          )}
+        </div>
         <Button
-          className="py-2 px-4 bg-violet-600 text-white border-violet-600 !rounded-l-none ring-0"
+          className={clsx(
+            'py-2 px-4 bg-violet-600 text-white border-violet-600 ring-0',
+            hasTemplates ? '' : '!rounded-l-none'
+          )}
           type="submit"
-          disabled={!newDigestTiltle || isLoading}
+          disabled={!title || (hasTemplates && !templateId) || isLoading}
           isLoading={isLoading || isRefreshing}
         >
           Create

--- a/src/components/digests/templates/CreateTemplateModal.tsx
+++ b/src/components/digests/templates/CreateTemplateModal.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import Button from '../../Button';
+import { Dialog, DialogContent, DialogTrigger } from '../../Dialog';
+import { useRouter } from 'next/navigation';
+import useCustomToast from '@/hooks/useCustomToast';
+import { useMutation } from 'react-query';
+import api from '@/lib/api';
+import { Input } from '../../Input';
+import { DigestBlock, Team } from '@prisma/client';
+
+const CreateTemplateModal = ({
+  team,
+  digestBlocks,
+}: {
+  team: Team;
+  digestBlocks: DigestBlock[];
+}) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const router = useRouter();
+  const { errorToast, successToast } = useCustomToast();
+
+  const { mutate: saveTemplate, isLoading } = useMutation(
+    'save-digest-template',
+    (title: string) =>
+      api.post(`/teams/${team.id}/digests`, {
+        title: `${team?.slug}-template-${title}`,
+        digestBlocks,
+        isTemplate: 'true',
+      }),
+    {
+      onSuccess: () => {
+        successToast('Your template has been saved');
+        setIsDialogOpen(false);
+        router.refresh();
+      },
+      onError: (error: any) => {
+        if (error.response.data.error) {
+          errorToast(error.response.data.error);
+        } else {
+          errorToast('Something went wrong...');
+        }
+      },
+    }
+  );
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const template = e.currentTarget.template.value;
+    if (!template) return;
+    saveTemplate(template);
+  };
+
+  if (!digestBlocks?.length) return null;
+  return (
+    <div className="py-4">
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger asChild>
+          <Button variant="link" size="sm">
+            save as template
+          </Button>
+        </DialogTrigger>
+        <DialogContent
+          containerClassName="w-full sm:max-w-md"
+          title="New Digest Template"
+          description="Save your digest text blocks as a template to reuse it as a layout for your next publications"
+          closeIcon
+        >
+          <form
+            className="w-full bg-gray-50 flex flex-col gap-4"
+            onSubmit={onSubmit}
+          >
+            <label htmlFor="template" className="hidden" aria-hidden="true">
+              template
+            </label>
+            <Input
+              type="text"
+              name="template"
+              id="template"
+              placeholder="Digest template name"
+              required
+              autoFocus
+            />
+            <Button isLoading={isLoading} type="submit">
+              Save
+            </Button>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default CreateTemplateModal;

--- a/src/components/digests/templates/SelectTemplateModal.tsx
+++ b/src/components/digests/templates/SelectTemplateModal.tsx
@@ -1,0 +1,44 @@
+import Button from '@/components/Button';
+import { Dialog, DialogTrigger, DialogContent } from '@/components/Dialog';
+import { Digest, Team } from '@prisma/client';
+import { useState } from 'react';
+import { DigestCreateInput } from '../DigestCreateInput';
+import { TeamDigestsResult } from '@/lib/queries';
+
+const SelectTemplateModal = ({
+  team,
+  templates,
+  predictedDigestTitle,
+}: {
+  templates: TeamDigestsResult[];
+  team: Team;
+  predictedDigestTitle: string | null;
+}) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <div className="flex justify-end">
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger asChild>
+          <Button variant="link">Use template</Button>
+        </DialogTrigger>
+        <DialogContent
+          containerClassName="w-full sm:max-w-md"
+          title="Create templated digest"
+          description="Create a new digest using one of your templates"
+          closeIcon
+        >
+          <div className="flex flex-col gap-4 w-full">
+            <DigestCreateInput
+              team={team}
+              predictedDigestTitle={predictedDigestTitle}
+              templates={templates}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default SelectTemplateModal;

--- a/src/components/digests/templates/TemplateEdit.tsx
+++ b/src/components/digests/templates/TemplateEdit.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { routes } from '@/core/constants';
+import useCustomToast from '@/hooks/useCustomToast';
+import useTransitionRefresh from '@/hooks/useTransitionRefresh';
+import api from '@/lib/api';
+
+import useAddAndRemoveBlockOnDigest from '@/hooks/useAddAndRemoveBlockOnDigest';
+import { getDigest, getTeamBySlug } from '@/lib/queries';
+import { ApiDigestResponseSuccess } from '@/pages/api/teams/[teamId]/digests';
+import { reorderList } from '@/utils/actionOnList';
+import { TrashIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import { DigestBlock, DigestBlockType } from '@prisma/client';
+import { AxiosError, AxiosResponse } from 'axios';
+import clsx from 'clsx';
+import { useState } from 'react';
+import {
+  DragDropContext,
+  DropResult,
+  resetServerContext,
+} from 'react-beautiful-dnd';
+import { useForm } from 'react-hook-form';
+import { useMutation } from 'react-query';
+import Button from '../../Button';
+import { Input } from '../../Input';
+import { DeletePopover } from '../../Popover';
+import { BlockListDnd } from '../../digests/BlockListDnd';
+import SectionContainer from '../../layout/SectionContainer';
+import { Breadcrumb } from '../../teams/Breadcrumb';
+import { formatTemplateTitle } from '../../digests/templates/TemplateItem';
+
+type Props = {
+  template: NonNullable<Awaited<ReturnType<typeof getDigest>>>;
+  team: Awaited<ReturnType<typeof getTeamBySlug>>;
+};
+
+type DigestData = {
+  title?: string;
+  description?: string;
+  publishedAt?: Date | null;
+  digestBlocks?: DigestBlock[];
+};
+
+export const TemplateEdit = ({ template, team }: Props) => {
+  const { push } = useRouter();
+  const { successToast, errorToast } = useCustomToast();
+  const [isMoving, setIsMoving] = useState(false);
+
+  resetServerContext();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isDirty },
+    reset,
+  } = useForm({
+    defaultValues: {
+      title: formatTemplateTitle(template?.title, team.slug),
+      description: template?.description,
+    },
+  });
+
+  const { add, order } = useAddAndRemoveBlockOnDigest({
+    teamId: team.id,
+    digestId: template.id,
+  });
+
+  const { refresh, isRefreshing } = useTransitionRefresh();
+  const { refresh: saveRefresh } = useTransitionRefresh();
+
+  const onDragEnd = async (result: DropResult) => {
+    if (!result.destination || result.destination.droppableId === 'bookmark') {
+      return;
+    }
+
+    setIsMoving(true);
+
+    if (result.source.droppableId === 'bookmark') {
+      await add.mutateAsync({
+        bookmarkId: result.draggableId,
+        position: result.destination.index,
+        type: DigestBlockType.BOOKMARK,
+      });
+    } else {
+      template.digestBlocks = reorderList(
+        template.digestBlocks,
+        result.source.index,
+        result.destination.index
+      );
+
+      await order.mutateAsync({
+        blockId: result.draggableId,
+        position: result.destination.index,
+      });
+    }
+
+    setIsMoving(false);
+  };
+
+  const { mutate: mutateSave, isLoading: isSaving } = useMutation<
+    DigestData,
+    AxiosError<ErrorResponse>,
+    DigestData
+  >(
+    ['patch-digest-save', team.id, template?.id],
+    (data: DigestData) => {
+      return api.patch(`/teams/${team.id}/digests/${template?.id}`, {
+        ...{ ...data, title: `${team.slug}-template-${data?.title}` },
+      });
+    },
+    {
+      onSuccess: (template: DigestData) => {
+        reset({ title: template?.title });
+        successToast('Your template has been updated');
+        saveRefresh();
+      },
+      onError: (error: AxiosError<ErrorResponse>) => {
+        errorToast(
+          error.response?.data?.error ||
+            error.response?.statusText ||
+            error.message
+        );
+      },
+    }
+  );
+
+  const { mutate: deleteDigest, isLoading: isDeleting } = useMutation<
+    AxiosResponse<ApiDigestResponseSuccess>,
+    AxiosError<ErrorResponse>
+  >(
+    'delete-digest',
+    () => {
+      return api.delete(`/teams/${team.id}/digests/${template.id}`);
+    },
+    {
+      onSuccess: () => {
+        successToast('Template has been deleted');
+        refresh();
+        push(routes.TEAM.replace(':slug', team.slug));
+      },
+      onError: (error) => {
+        errorToast(
+          error.response?.data?.error ||
+            error.response?.statusText ||
+            error.message
+        );
+      },
+    }
+  );
+
+  const onBlur = (data: any) => {
+    if (!isDirty) return;
+    mutateSave(data);
+  };
+
+  return (
+    <div className="pb-4">
+      <Breadcrumb
+        paths={[
+          {
+            name: team.name,
+            href: routes.TEAM.replace(':slug', team.slug),
+          },
+          {
+            name: 'Template edition',
+          },
+        ]}
+      />
+      <div className="flex flex-col gap-5 items-stretch justify-start md:flex-row">
+        <DragDropContext onDragEnd={onDragEnd}>
+          <SectionContainer className={clsx(' w-full h-min')}>
+            <form className="flex flex-col gap-5" onBlur={handleSubmit(onBlur)}>
+              <div className="flex justify-between">
+                <div className="flex justify-between">
+                  <InformationCircleIcon className="w-6 h-6 mr-2" />
+                  <span className="italic">
+                    Editing this template will not affect already created
+                    digests
+                  </span>
+                </div>
+                <DeletePopover
+                  handleDelete={deleteDigest}
+                  isLoading={isDeleting}
+                  trigger={
+                    <Button
+                      aria-label="Delete template"
+                      icon={<TrashIcon />}
+                      variant="destructiveGhost"
+                      isLoading={isDeleting || isRefreshing}
+                    >
+                      Delete template
+                    </Button>
+                  }
+                />
+              </div>
+
+              <div className="w-full items-start flex flex-col gap-6">
+                <Input
+                  placeholder="Add a title"
+                  {...register('title')}
+                  className="!text-3xl !font-bold px-4 !py-4"
+                />
+              </div>
+              <div
+                className={clsx(
+                  'flex flex-col w-full',
+                  (isMoving ||
+                    isRefreshing ||
+                    add.isLoading ||
+                    order.isLoading) &&
+                    'pointer-events-none cursor-not-allowed opacity-60'
+                )}
+              >
+                <BlockListDnd digest={template} team={team} />
+              </div>
+            </form>
+          </SectionContainer>
+        </DragDropContext>
+      </div>
+    </div>
+  );
+};

--- a/src/components/digests/templates/TemplateItem.tsx
+++ b/src/components/digests/templates/TemplateItem.tsx
@@ -1,0 +1,78 @@
+import { DeletePopover } from '@/components/Popover';
+import { Digest, Team } from '@prisma/client';
+import { TrashIcon } from '@heroicons/react/24/outline';
+import Button from '@/components/Button';
+import { useMutation } from 'react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+import { ApiDigestResponseSuccess } from '@/pages/api/teams/[teamId]/digests';
+import api from '@/lib/api';
+import useCustomToast from '@/hooks/useCustomToast';
+import useTransitionRefresh from '@/hooks/useTransitionRefresh';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+
+export const formatTemplateTitle = (title: string, teamSlug: string) => {
+  return title.replace(`${teamSlug}-template-`, '');
+};
+
+const TemplateItem = ({ template, team }: { template: Digest; team: Team }) => {
+  const { successToast, errorToast } = useCustomToast();
+  const { refresh, isRefreshing } = useTransitionRefresh();
+  const { mutate: deleteTemplate, isLoading: isDeleting } = useMutation<
+    AxiosResponse<ApiDigestResponseSuccess>,
+    AxiosError<ErrorResponse>
+  >(
+    'delete-template',
+    () => {
+      return api.delete(`/teams/${team.id}/digests/${template.id}`);
+    },
+    {
+      onSuccess: () => {
+        successToast('Template has been deleted');
+        refresh();
+      },
+      onError: (error) => {
+        errorToast(
+          error.response?.data?.error ||
+            error.response?.statusText ||
+            error.message
+        );
+      },
+    }
+  );
+
+  return (
+    <div className="flex justify-between items-center w-full">
+      <span>{formatTemplateTitle(template?.title, team.slug)}</span>
+      <div className="flex gap-x-4">
+        <DeletePopover
+          handleDelete={() => deleteTemplate()}
+          isLoading={isDeleting}
+          trigger={
+            <Button
+              className="w-1"
+              aria-label="Delete template"
+              icon={<TrashIcon />}
+              variant="destructiveOutline"
+              isLoading={isDeleting}
+            />
+          }
+        />
+        <Link
+          href={`/teams/${team.slug}/digests/${template.id}/edit`}
+          prefetch={false}
+        >
+          <Button
+            className="w-1"
+            aria-label="Edit template"
+            icon={<PencilSquareIcon />}
+            variant="outline"
+            isLoading={isDeleting}
+          />
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateItem;

--- a/src/components/pages/DigestEditPage.tsx
+++ b/src/components/pages/DigestEditPage.tsx
@@ -38,6 +38,7 @@ import DigestEditVisit from './DigestEditVisit';
 import DigestEditTypefully from './DigestEditTypefully';
 import DigestEditSendNewsletter from './DigestEditSendNewsletter';
 import { EyeIcon } from '@heroicons/react/24/solid';
+import CreateTemplateModal from '../digests/templates/CreateTemplateModal';
 
 type Props = {
   teamLinksData: TeamLinksData;
@@ -145,8 +146,9 @@ export const DigestEditPage = ({
     DigestData
   >(
     ['patch-digest-save', team.id, digest?.id],
-    (data: DigestData) =>
-      api.patch(`/teams/${team.id}/digests/${digest?.id}`, { ...data }),
+    (data: DigestData) => {
+      return api.patch(`/teams/${team.id}/digests/${digest?.id}`, { ...data });
+    },
     {
       onSuccess: (digest: DigestData) => {
         reset({ title: digest?.title, description: digest?.description });
@@ -306,7 +308,8 @@ export const DigestEditPage = ({
               </div>
             </SectionContainer>
           </div>
-          <SectionContainer className="md:w-1/2 w-full h-min">
+
+          <SectionContainer className={clsx(' w-full h-min md:w-1/2')}>
             <form className="flex flex-col gap-5" onBlur={handleSubmit(onBlur)}>
               <div className="w-full items-start flex flex-col gap-6">
                 <Input
@@ -314,11 +317,18 @@ export const DigestEditPage = ({
                   {...register('title')}
                   className="!text-3xl !font-bold px-4 !py-4"
                 />
+
                 <TextArea
                   placeholder="Add a description"
                   {...register('description')}
                 />
               </div>
+              <CreateTemplateModal
+                team={team}
+                digestBlocks={digest?.digestBlocks.filter(
+                  (block) => block?.type === 'TEXT'
+                )}
+              />
               <div
                 className={clsx(
                   'flex flex-col w-full',

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -11,12 +11,14 @@ import { Digests } from '../digests/Digests';
 import NoContent from '../layout/NoContent';
 import PageContainer from '../layout/PageContainer';
 import Pagination from '../list/Pagination';
+import SelectTemplateModal from '../digests/templates/SelectTemplateModal';
 
 type Props = {
   linkCount: number;
   teamLinks: TeamLinks;
   digests: TeamDigestsResult[];
   digestsCount: number;
+  templates: TeamDigestsResult[];
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
   search?: string;
 };
@@ -28,6 +30,7 @@ const Team = ({
   digests,
   digestsCount,
   search,
+  templates,
 }: Props) => {
   return (
     <PageContainer title={team.name}>
@@ -78,11 +81,19 @@ const Team = ({
           }
         >
           <div className="flex flex-col gap-4 w-full">
-            <DigestCreateInput
-              teamId={team.id}
-              teamSlug={team.slug}
-              predictedDigestTitle={team?.nextSuggestedDigestTitle}
-            />
+            <div>
+              <DigestCreateInput
+                team={team}
+                predictedDigestTitle={team?.nextSuggestedDigestTitle}
+              />
+              {!!templates?.length && (
+                <SelectTemplateModal
+                  templates={templates}
+                  team={team}
+                  predictedDigestTitle={team?.nextSuggestedDigestTitle}
+                />
+              )}
+            </div>
             <Digests digests={digests} teamSlug={team.slug} />
             <Pagination
               totalItems={digestsCount}

--- a/src/components/teams/TeamSettings.tsx
+++ b/src/components/teams/TeamSettings.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { routes } from '@/core/constants';
-import { Member, TeamInvitation } from '@/lib/queries';
+import { Member, TeamDigestsResult, TeamInvitation } from '@/lib/queries';
 import { Subscription, Team } from '@prisma/client';
 import PageContainer from '../layout/PageContainer';
 import SectionContainer from '../layout/SectionContainer';
@@ -10,6 +10,8 @@ import { Breadcrumb } from './Breadcrumb';
 import SettingsForm from './form/settings/SettingsForm';
 import TeamSettingsMembers from './TeamSettingsMembers';
 import { Session } from 'next-auth';
+import TeamTemplates from './form/settings/TeamTemplates';
+import TeamIntegrations from './form/settings/TeamIntegrations';
 
 type Props = {
   team: Team;
@@ -17,6 +19,7 @@ type Props = {
   subscriptions: Subscription[];
   invitations: TeamInvitation[];
   user: Session['user'];
+  templates: TeamDigestsResult[];
 };
 
 export const TeamSettings = ({
@@ -25,6 +28,7 @@ export const TeamSettings = ({
   invitations,
   user,
   subscriptions,
+  templates,
 }: Props) => {
   if (!team || !members || !subscriptions) return <Loader fullPage />;
 
@@ -49,6 +53,8 @@ export const TeamSettings = ({
         <div className="flex flex-col md:flex-row gap-10 ">
           <div className="rounded-lg w-full md:w-1/2 lg:w-[55%]">
             <SettingsForm team={team} />
+            <TeamTemplates team={team} templates={templates} />
+            <TeamIntegrations team={team} />
           </div>
           <div className="w-full md:w-1/2 lg:w-[45%]">
             <TeamSettingsMembers

--- a/src/components/teams/form/settings/SettingsForm.tsx
+++ b/src/components/teams/form/settings/SettingsForm.tsx
@@ -101,24 +101,6 @@ const SettingsForm = ({ team }: { team: Team }) => {
                 <DangerZoneTeam team={team} />
               </div>
             </div>
-
-            <div className="relative py-5">
-              <div
-                className="absolute inset-0 flex items-center "
-                aria-hidden="true"
-              >
-                <div className="w-full border-t border-gray-300" />
-              </div>
-            </div>
-            <span>
-              <h3 className="text-lg font-semibold leading-7">Integrations</h3>
-              <span className="text-sm text-gray-500 font-light">
-                Increase your digest reach by integrating with other tools.
-              </span>
-            </span>
-            <SlackPanel team={team} />
-            <TypefullyPanel team={team} />
-            <TeamAPIKey team={team} />
           </div>
         </div>
       </form>

--- a/src/components/teams/form/settings/TeamIntegrations.tsx
+++ b/src/components/teams/form/settings/TeamIntegrations.tsx
@@ -1,0 +1,27 @@
+import SlackPanel from '../SlackPanel';
+import TypefullyPanel from '../TypefullyPanel';
+import TeamAPIKey from '../TeamAPIKey';
+import { Team } from '@prisma/client';
+
+const TeamIntegrations = ({ team }: { team: Team }) => {
+  return (
+    <div>
+      <div className="relative py-5">
+        <div className="absolute inset-0 flex items-center " aria-hidden="true">
+          <div className="w-full border-t border-gray-300" />
+        </div>
+      </div>
+      <span>
+        <h3 className="text-lg font-semibold leading-7">Integrations</h3>
+        <span className="text-sm text-gray-500 font-light">
+          Increase your digest reach by integrating with other tools.
+        </span>
+      </span>
+      <SlackPanel team={team} />
+      <TypefullyPanel team={team} />
+      <TeamAPIKey team={team} />
+    </div>
+  );
+};
+
+export default TeamIntegrations;

--- a/src/components/teams/form/settings/TeamTemplates.tsx
+++ b/src/components/teams/form/settings/TeamTemplates.tsx
@@ -9,6 +9,8 @@ const TeamTemplates = ({
   team: Team;
   templates: TeamDigestsResult[];
 }) => {
+  if (!templates?.length) return null;
+
   return (
     <div className="pt-6">
       <div className="w-full border-t border-gray-300 pb-6" />

--- a/src/components/teams/form/settings/TeamTemplates.tsx
+++ b/src/components/teams/form/settings/TeamTemplates.tsx
@@ -16,9 +16,11 @@ const TeamTemplates = ({
       <span className="text-sm text-gray-500 font-light">
         Manage your team templates
       </span>
-      {templates?.map((template) => (
-        <TemplateItem key={template?.id} template={template} team={team} />
-      ))}
+      <div className="flex gap-4 flex-col">
+        {templates?.map((template) => (
+          <TemplateItem key={template?.id} template={template} team={team} />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/teams/form/settings/TeamTemplates.tsx
+++ b/src/components/teams/form/settings/TeamTemplates.tsx
@@ -1,0 +1,26 @@
+import TemplateItem from '@/components/digests/templates/TemplateItem';
+import { TeamDigestsResult } from '@/lib/queries';
+import { Team } from '@prisma/client';
+
+const TeamTemplates = ({
+  team,
+  templates,
+}: {
+  team: Team;
+  templates: TeamDigestsResult[];
+}) => {
+  return (
+    <div className="pt-6">
+      <div className="w-full border-t border-gray-300 pb-6" />
+      <h3 className="text-lg font-semibold leading-7">Templates</h3>
+      <span className="text-sm text-gray-500 font-light">
+        Manage your team templates
+      </span>
+      {templates?.map((template) => (
+        <TemplateItem key={template?.id} template={template} team={team} />
+      ))}
+    </div>
+  );
+};
+
+export default TeamTemplates;

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -263,7 +263,8 @@ export type TeamBookmarkedLinkItem = TeamLinks[number];
 export const getTeamDigests = async (
   teamId: string,
   page?: number,
-  perPage = 30
+  perPage = 30,
+  isTemplate = false
 ) => {
   const digestsCount = await db.digest.count({
     where: {
@@ -275,6 +276,7 @@ export const getTeamDigests = async (
     skip: page ? (page - 1) * perPage : 0,
     where: {
       teamId,
+      isTemplate,
     },
     include: {
       digestBlocks: true,

--- a/src/pages/api/teams/[teamId]/digests/index.ts
+++ b/src/pages/api/teams/[teamId]/digests/index.ts
@@ -1,10 +1,11 @@
 import client, { isUniqueConstraintError } from '@/lib/db';
 import { checkTeam } from '@/lib/middleware';
-import { Digest } from '@prisma/client';
+import { Digest, DigestBlock, DigestBlockType } from '@prisma/client';
 import { AuthApiRequest, errorHandler } from '@/lib/router';
 import { NextApiResponse } from 'next';
 import { createRouter } from 'next-connect';
 import urlSlug from 'url-slug';
+import { CreateBlockData, createDigestBlock } from './[digestId]/block';
 
 export type ApiDigestResponseSuccess = Digest;
 
@@ -12,15 +13,68 @@ export const router = createRouter<AuthApiRequest, NextApiResponse>();
 
 router.use(checkTeam).post(async (req, res) => {
   try {
-    const digest = await client.digest.create({
-      data: {
-        teamId: req.teamId!,
-        title: req.body.title,
-        slug: urlSlug(req.body.title),
-      },
-    });
+    const { title, isTemplate, templateId } = req.body;
+    const teamId = req.teamId!;
 
-    return res.status(201).json(digest);
+    const newDigest = (await client.digest.create({
+      data: {
+        teamId,
+        title: title,
+        slug: urlSlug(title),
+        isTemplate: Boolean(isTemplate),
+      },
+      include: {
+        digestBlocks: true,
+      },
+    })) as Digest & {
+      digestBlocks: DigestBlock[];
+    };
+
+    if (templateId) {
+      const template = await client.digest.findUnique({
+        where: {
+          id: templateId,
+        },
+        include: {
+          digestBlocks: true,
+        },
+      });
+
+      const templateBlocks = await client.digestBlock.findMany({
+        where: {
+          digestId: templateId,
+        },
+      });
+
+      // Createnew blocks to add to digest if template was provided
+      if (template && templateBlocks) {
+        await Promise.all(
+          templateBlocks.map(async (block) => {
+            return await createDigestBlock(
+              {
+                ...block,
+                isTemplate: false,
+              } as CreateBlockData,
+              newDigest
+            );
+          })
+        );
+      }
+    }
+
+    if (isTemplate) {
+      await Promise.all(
+        req.body.digestBlocks.map(async (block: CreateBlockData) => {
+          const { text, position } = block;
+          await createDigestBlock(
+            { type: DigestBlockType.TEXT, text, position, isTemplate: true },
+            newDigest
+          );
+        })
+      );
+    }
+
+    return res.status(201).json(newDigest);
   } catch (e) {
     return res.status(400).json(
       isUniqueConstraintError(e) && {


### PR DESCRIPTION
**Issue**
https://github.com/premieroctet/digestclub/issues/43

**Description**
Will save all markdown and text blocks into a template digest to reuse it for next digests
- template creation
- template edition
- template deletion


**ScreenShots**
Pick a template
![image](https://github.com/premieroctet/digestclub/assets/25606391/f5578f0c-dcbe-4c61-acc8-99af43f34fde)

Save a template from DigestEditPage
![image](https://github.com/premieroctet/digestclub/assets/25606391/c2ec11bd-b7a0-4aa5-9fcc-b7963a087287)

Manage your templates
![image](https://github.com/premieroctet/digestclub/assets/25606391/2108b6f8-ba76-4fc3-b26d-59e5d253fc50)

Edit your template
![image](https://github.com/premieroctet/digestclub/assets/25606391/ab38dbe2-0cc4-4749-8f6f-c92536b5ad2c)
