### PR TITLE
Pagination for digests on team page and dashboard page

### DIFF
--- a/src/app/(routes)/discover/page.tsx
+++ b/src/app/(routes)/discover/page.tsx
@@ -15,7 +15,7 @@ const DiscoverPage = async ({ searchParams }: TeamPageProps) => {
   const page = Number(searchParams?.page || 1);
 
   const recentTeams = await getRecentTeams();
-  const { digests, totalCount } = await getDiscoverDigests({
+  const { digests, digestsCount } = await getDiscoverDigests({
     page,
     perPage: PER_PAGE,
   });
@@ -25,7 +25,7 @@ const DiscoverPage = async ({ searchParams }: TeamPageProps) => {
       <div className="flex gap-4">
         <div className="md:w-9/12 flex justify-between items-center gap-3 w-full">
           <h1 className="font-bold text-3xl my-4">Community Digests</h1>
-          <Pagination totalItems={totalCount} itemsPerPage={PER_PAGE} />
+          <Pagination totalItems={digestsCount} itemsPerPage={PER_PAGE} />
         </div>
         <div className="md:max-w-[22rem] md:block hidden w-full"></div>
       </div>

--- a/src/app/(routes)/teams/[teamSlug]/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/page.tsx
@@ -37,22 +37,28 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
 
   await updateDefaultTeam(user.id, team.id);
 
-  const page = Number(searchParams?.page || 1);
+  const linksPage = Number(searchParams?.page || 1);
   const search = searchParams?.search || '';
-  const { totalCount, teamLinks } = await getTeamLinks(team.id, {
-    page,
+  const { linksCount, teamLinks } = await getTeamLinks(team.id, {
+    page: linksPage,
     onlyNotInDigest: !searchParams?.all,
     search,
   });
 
-  const digests = await getTeamDigests(team.id, 1, 11);
+  const digestsPage = Number(searchParams?.digestPage || 1);
+  const { digests, digestsCount } = await getTeamDigests(
+    team.id,
+    digestsPage,
+    8
+  );
 
   return (
     <Team
       team={team}
-      linkCount={totalCount}
+      linkCount={linksCount}
       teamLinks={teamLinks}
       digests={digests}
+      digestsCount={digestsCount}
       search={search}
     />
   );

--- a/src/components/home/HomeDigests.tsx
+++ b/src/components/home/HomeDigests.tsx
@@ -1,33 +1,10 @@
-import db from '@/lib/db';
-import { DigestBlockType } from '@prisma/client';
 import PublicDigestCard from '../teams/PublicDigestCard';
+import { getDiscoverDigests } from '@/lib/queries';
 
 const HomeDigests = async () => {
-  const digests = await db.digest.findMany({
-    take: 3,
-    orderBy: { publishedAt: 'desc' },
-    where: { publishedAt: { not: null } },
-    select: {
-      id: true,
-      publishedAt: true,
-      title: true,
-      description: true,
-      slug: true,
-      team: true,
-      digestBlocks: {
-        select: {
-          id: true,
-          bookmark: {
-            select: {
-              link: {
-                select: { title: true, blurHash: true, url: true, image: true },
-              },
-            },
-          },
-        },
-        where: { type: DigestBlockType.BOOKMARK },
-      },
-    },
+  const { digests } = await getDiscoverDigests({
+    page: 1,
+    perPage: 3,
   });
 
   return (

--- a/src/components/list/Pagination.tsx
+++ b/src/components/list/Pagination.tsx
@@ -8,12 +8,14 @@ import { HTMLProps, useEffect, useState, useTransition } from 'react';
 type Props = {
   totalItems: number;
   itemsPerPage?: number;
+  pageParamName?: string;
 };
 
 const Pagination = ({
   totalItems,
   itemsPerPage = 10,
   className,
+  pageParamName = 'page',
   ...props
 }: Props & HTMLProps<HTMLDivElement>) => {
   const { push } = useRouter();
@@ -22,14 +24,14 @@ const Pagination = ({
   const [isRefreshing, startTransition] = useTransition();
   const [action, setAction] = useState<'prev' | 'next'>();
 
-  const currentPage = Number(searchParams?.get('page')) || 1;
+  const currentPage = Number(searchParams?.get(pageParamName)) || 1;
 
   const totalPages =
     totalItems < itemsPerPage ? 1 : Math.ceil(totalItems / itemsPerPage);
 
   const handlePageChange = (page: number) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('page', page.toString());
+    params.set(pageParamName, page.toString());
 
     startTransition(() => {
       push(path + `?${params.toString()}`);

--- a/src/components/pages/DigestEditPage.tsx
+++ b/src/components/pages/DigestEditPage.tsx
@@ -53,7 +53,7 @@ type DigestData = {
 };
 
 export const DigestEditPage = ({
-  teamLinksData: { totalCount, teamLinks, perPage },
+  teamLinksData: { linksCount, teamLinks, perPage },
   digest,
   team,
 }: Props) => {
@@ -281,7 +281,7 @@ export const DigestEditPage = ({
 
             <SectionContainer title="Bookmarks" className="relative">
               <Pagination
-                totalItems={totalCount}
+                totalItems={linksCount}
                 itemsPerPage={perPage}
                 className="absolute top-5 right-5"
               />
@@ -302,7 +302,7 @@ export const DigestEditPage = ({
                 )}
               </div>
               <div className="flex justify-end">
-                <Pagination totalItems={totalCount} itemsPerPage={perPage} />
+                <Pagination totalItems={linksCount} itemsPerPage={perPage} />
               </div>
             </SectionContainer>
           </div>

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -10,16 +10,25 @@ import { DigestCreateInput } from '../digests/DigestCreateInput';
 import { Digests } from '../digests/Digests';
 import NoContent from '../layout/NoContent';
 import PageContainer from '../layout/PageContainer';
+import Pagination from '../list/Pagination';
 
 type Props = {
   linkCount: number;
   teamLinks: TeamLinks;
   digests: TeamDigestsResult[];
+  digestsCount: number;
   team: Awaited<ReturnType<typeof getTeamBySlug>>;
   search?: string;
 };
 
-const Team = ({ team, linkCount, teamLinks, digests, search }: Props) => {
+const Team = ({
+  team,
+  linkCount,
+  teamLinks,
+  digests,
+  digestsCount,
+  search,
+}: Props) => {
   return (
     <PageContainer title={team.name}>
       <div className="flex max-lg:flex-col gap-5 pb-4">
@@ -60,7 +69,7 @@ const Team = ({ team, linkCount, teamLinks, digests, search }: Props) => {
             <div className="flex justify-between items-center">
               <div className="flex items-center gap-3">
                 <h2 className="text-xl">Digests</h2>
-                <CounterTag count={digests.length} />
+                <CounterTag count={digestsCount} />
               </div>
               <Link className="text-sm underline" href={`/${team.slug}`}>
                 Show all digests
@@ -75,6 +84,12 @@ const Team = ({ team, linkCount, teamLinks, digests, search }: Props) => {
               predictedDigestTitle={team?.nextSuggestedDigestTitle}
             />
             <Digests digests={digests} teamSlug={team.slug} />
+            <Pagination
+              totalItems={digestsCount}
+              pageParamName="digestPage"
+              className="h-6"
+              itemsPerPage={8}
+            />
           </div>
         </Card>
       </div>

--- a/src/components/pages/TeamPublicPage.tsx
+++ b/src/components/pages/TeamPublicPage.tsx
@@ -1,16 +1,20 @@
-import { PublicTeamResult } from '@/lib/queries';
+import { DiscoveryDigest, PublicTeamResult } from '@/lib/queries';
 import { getEnvHost } from '@/lib/server';
 import { BookmarkIcon } from '@heroicons/react/24/solid';
 import RssButton from '../RssButton';
 import NoContent from '../layout/NoContent';
 import PublicPageTemplate from '../layout/PublicPageTemplate';
 import PublicDigestListItem from '../teams/PublicDigestListItem';
+import Pagination from '../list/Pagination';
+import { Team } from '@prisma/client';
 
 export interface Props {
-  team: NonNullable<PublicTeamResult>;
+  team: Team;
+  digestsCount: number;
+  digests: DiscoveryDigest[];
 }
 
-const TeamPublicPage = ({ team }: Props) => {
+const TeamPublicPage = ({ team, digestsCount, digests }: Props) => {
   return (
     <PublicPageTemplate team={team}>
       <div className="bg-white w-fullflex-col rounded-lg border border-gray-200">
@@ -21,8 +25,8 @@ const TeamPublicPage = ({ team }: Props) => {
           <RssButton copyText={`${getEnvHost()}/${team.slug}/rss.xml`} />
         </div>
       </div>
-      <div className="w-full">
-        {team.Digest.length === 0 ? (
+      <div className="w-full pb-6">
+        {digestsCount === 0 ? (
           <NoContent
             icon={<BookmarkIcon className="h-20 w-20" />}
             title="No Digest"
@@ -30,13 +34,17 @@ const TeamPublicPage = ({ team }: Props) => {
           />
         ) : (
           <div className="mt-3 gap-4 flex flex-col">
-            {team.Digest.slice(0, 10).map((digest) => (
+            {digests.map((digest) => (
               <PublicDigestListItem
                 key={digest.slug}
                 digest={digest}
                 team={team}
               />
             ))}
+            <Pagination
+              totalItems={digestsCount}
+              className="justify-end flex"
+            />
           </div>
         )}
       </div>

--- a/src/components/teams/PublicDigestCard.tsx
+++ b/src/components/teams/PublicDigestCard.tsx
@@ -1,4 +1,4 @@
-import { PublicTeamResult } from '@/lib/queries';
+import { DiscoveryDigest, PublicTeamResult } from '@/lib/queries';
 import { formatDate } from '@/utils/date';
 import { generateDigestOGUrl } from '@/utils/open-graph-url';
 import { Team } from '@prisma/client';
@@ -7,7 +7,7 @@ import BookmarkCountBadge from './BookmarkCountBadge';
 import TeamAvatar from './TeamAvatar';
 
 interface Props {
-  digest: NonNullable<PublicTeamResult>['Digest'][number];
+  digest: DiscoveryDigest;
   showTeam?: boolean;
   team: Partial<Team>;
 }

--- a/src/components/teams/PublicDigestListItem.tsx
+++ b/src/components/teams/PublicDigestListItem.tsx
@@ -1,4 +1,4 @@
-import { PublicTeamResult } from '@/lib/queries';
+import { DiscoveryDigest } from '@/lib/queries';
 import { formatDate } from '@/utils/date';
 import { generateDigestOGUrl } from '@/utils/open-graph-url';
 import { Team } from '@prisma/client';
@@ -8,7 +8,7 @@ import BookmarkCountBadge from './BookmarkCountBadge';
 import TeamAvatar from './TeamAvatar';
 
 interface Props {
-  digest: NonNullable<PublicTeamResult>['Digest'][number];
+  digest: DiscoveryDigest;
   showTeam?: boolean;
   team: Partial<Team>;
 }

--- a/src/pages/admin/[[...nextadmin]].tsx
+++ b/src/pages/admin/[[...nextadmin]].tsx
@@ -27,7 +27,7 @@ type DashboardProps = {
   newUsersByMonth: Awaited<ReturnType<typeof newUsersByMonth>>;
   newDigestByMonth: Awaited<ReturnType<typeof newDigestByMonth>>;
   linksByDomain: Awaited<ReturnType<typeof linksByDomain>>;
-  totalLinks: number;
+  linksCount: number;
   latestTeam: Team | null;
   latestDigest: Digest | null;
   linksByDay: Awaited<ReturnType<typeof linksByDay>>;
@@ -78,7 +78,7 @@ export default function Admin(
             </Card>
             <Card>
               <Text>Total des liens</Text>
-              <Metric>{dashboardProps?.totalLinks}</Metric>
+              <Metric>{dashboardProps?.linksCount}</Metric>
             </Card>
             <Col numColSpan={3} numColSpanLg={3}>
               <LinksOverTime data={{ linksByDay: dashboardProps.linksByDay }} />
@@ -213,7 +213,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
       newDigestByMonth: await newDigestByMonth(),
       linksByDomain: await linksByDomain(),
       linksByDay: await linksByDay(),
-      totalLinks: await client.link.count(),
+      linksCount: await client.link.count(),
       latestDigest: await client.digest.findFirst({
         where: { publishedAt: { not: null } },
         orderBy: { createdAt: 'desc' },


### PR DESCRIPTION
**Issue**
https://github.com/premieroctet/digestclub/issues/54

**Description**
Pagination for digests lists
- dashboard
- team public page
- specify count names for lists instead of totalCount

**Screenshot**
Team Public page
<img width="1178" alt="image" src="https://github.com/premieroctet/digestclub/assets/25606391/78a949fe-262c-4068-b145-3de64bc975fd">

Dashboard page
<img width="1207" alt="image" src="https://github.com/premieroctet/digestclub/assets/25606391/b3d175f8-508b-4ca0-984e-cca77f222746">
