### PR TITLE
feat(charts): Add Bookmarked link metrics in Team page

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-hot-toast": "^2.4.0",
     "react-query": "^3.39.3",
     "react-tweet": "^3.1.1",
+    "recharts": "^2.9.3",
     "remark": "^14.0.3",
     "remark-html": "^15.0.2",
     "satori": "^0.10.2",
@@ -93,8 +94,11 @@
     "@types/lodash": "^4.14.194",
     "@types/mjml": "^4.7.0",
     "@types/mjml-react": "^2.0.6",
+    "@types/node": "^18",
     "@types/nodemailer": "^6.4.7",
+    "@types/react": "^18",
     "@types/react-beautiful-dnd": "^13.1.4",
+    "@types/react-dom": "^18",
     "autoprefixer": "^10.4.14",
     "clsx": "^1.2.1",
     "cross-env": "^7.0.3",
@@ -107,9 +111,6 @@
     "tailwindcss-animate": "^1.0.5",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5",
-    "@types/node": "^18",
-    "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "typescript": "^5"
   }
 }

--- a/src/app/(routes)/teams/[teamSlug]/page.tsx
+++ b/src/app/(routes)/teams/[teamSlug]/page.tsx
@@ -5,6 +5,7 @@ import {
   getTeamLinks,
   getTeamDigests,
   updateDefaultTeam,
+  countAllTeamLinks,
 } from '@/lib/queries';
 import { getCurrentUserOrRedirect } from '@/lib/sessions';
 import { Metadata } from 'next';
@@ -39,11 +40,12 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
 
   const linksPage = Number(searchParams?.page || 1);
   const search = searchParams?.search || '';
-  const { linksCount, teamLinks } = await getTeamLinks(team.id, {
+  const { teamLinks } = await getTeamLinks(team.id, {
     page: linksPage,
     onlyNotInDigest: !searchParams?.all,
     search,
   });
+  const totalLinksCount = await countAllTeamLinks(team.id);
 
   const digestsPage = Number(searchParams?.digestPage || 1);
   const { digests, digestsCount } = await getTeamDigests(
@@ -56,7 +58,7 @@ const TeamPage = async ({ params, searchParams }: TeamPageProps) => {
   return (
     <Team
       team={team}
-      linkCount={linksCount}
+      linkCount={totalLinksCount}
       teamLinks={teamLinks}
       digests={digests}
       digestsCount={digestsCount}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,10 +6,12 @@ export const Card = ({
   header,
   footer,
   className,
+  contentClassName,
   ...props
 }: PropsWithChildren & {
   header?: ReactNode;
   footer?: ReactNode;
+  contentClassName?: string;
 } & HTMLProps<HTMLDivElement>) => {
   return (
     <section
@@ -20,7 +22,12 @@ export const Card = ({
       {...props}
     >
       {header && <div className="p-4">{header}</div>}
-      <div className="px-4 py-5 sm:p-6 w-full flex justify-center">
+      <div
+        className={clsx(
+          'px-4 py-5 sm:p-6 w-full flex justify-center',
+          contentClassName
+        )}
+      >
         {children}
       </div>
       {footer && <div className="px-4 py-4 sm:px-6">{footer}</div>}

--- a/src/components/bookmark/BookmarksListControls.tsx
+++ b/src/components/bookmark/BookmarksListControls.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { PropsWithChildren, useState } from 'react';
 import Pagination from '../list/Pagination';
 import clsx from 'clsx';

--- a/src/components/charts/Charts.tsx
+++ b/src/components/charts/Charts.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { Tooltip, ResponsiveContainer, Line, LineChart } from 'recharts';
 
-import CustomTooltip from './Tooltip';
+import ChartsTooltip from './ChartsTooltip';
 interface Props {
   teamLinksByMonth: Array<{
     month: number;
@@ -49,7 +49,7 @@ export default function ClientCharts({ teamLinksByMonth }: Props) {
         data={data}
         margin={{ top: 0, right: 20, left: 20, bottom: 6 }}
       >
-        <Tooltip content={<CustomTooltip />} />
+        <Tooltip content={<ChartsTooltip />} />
         <Line
           baseLine={0}
           type="monotone"

--- a/src/components/charts/Charts.tsx
+++ b/src/components/charts/Charts.tsx
@@ -1,0 +1,70 @@
+'use client';
+import React from 'react';
+
+import { Tooltip, ResponsiveContainer, Line, LineChart } from 'recharts';
+
+import CustomTooltip from './Tooltip';
+interface Props {
+  teamLinksByMonth: Array<{
+    month: number;
+    link_count: number;
+  }>;
+}
+
+type GraphData = Array<{
+  month: (typeof MONTH_SHORT_NAMES)[number];
+  amt: number;
+}>;
+
+const MONTH_SHORT_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sept',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;
+
+function refinePropToData(props: Props['teamLinksByMonth']): GraphData {
+  return MONTH_SHORT_NAMES.map((month, index) => {
+    const monthData = props.find((d) => d.month === index + 1);
+    return {
+      month,
+      amt: monthData ? monthData.link_count : 0,
+    };
+  });
+}
+
+export default function ClientCharts({ teamLinksByMonth }: Props) {
+  const data = refinePropToData(teamLinksByMonth);
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart
+        data={data}
+        margin={{ top: 0, right: 20, left: 20, bottom: 6 }}
+      >
+        <Tooltip content={<CustomTooltip />} />
+        <Line
+          baseLine={0}
+          type="monotone"
+          strokeWidth={2}
+          dataKey="amt"
+          stroke="#7C3AED80"
+          dot={false}
+          activeDot={{
+            stroke: '#7C3AED80',
+            strokeWidth: 2,
+            r: 4,
+            fill: '#FFF',
+          }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/Charts.tsx
+++ b/src/components/charts/Charts.tsx
@@ -47,7 +47,7 @@ export default function ClientCharts({ teamLinksByMonth }: Props) {
     <ResponsiveContainer width="100%" height="100%">
       <LineChart
         data={data}
-        margin={{ top: 0, right: 20, left: 20, bottom: 6 }}
+        margin={{ top: 6, right: 20, left: 20, bottom: 6 }}
       >
         <Tooltip content={<ChartsTooltip />} />
         <Line

--- a/src/components/charts/ChartsServer.tsx
+++ b/src/components/charts/ChartsServer.tsx
@@ -31,16 +31,23 @@ GROUP BY
 }
 
 export default async function ChartsServer({ linkCount, teamId }: Props) {
-  const teamLinkCount = await getTeamLinksCountByMonth(teamId);
+  const teamLinkCountByMonth = await getTeamLinksCountByMonth(teamId);
+  const emptyCount = teamLinkCountByMonth.length === 0;
+  const text = linkCount > 1 ? 'bookmarks' : 'bookmark';
+  if (emptyCount) {
+    return null;
+  }
 
   return (
     <div className="h-full flex flex-grow-0 w-ful items-end">
       <p className="flex flex-col justify-end">
         <span className="text-3xl font-bold">{linkCount}</span>
-        <span className="text-xs whitespace-nowrap">bookmarks</span>
+        <span title="Link bookmarked" className="text-xs text-gray-400">
+          {text}
+        </span>
       </p>
       <div className="h-[60px] w-full">
-        <Charts teamLinksByMonth={teamLinkCount} />
+        <Charts teamLinksByMonth={teamLinkCountByMonth} />
       </div>
     </div>
   );

--- a/src/components/charts/ChartsServer.tsx
+++ b/src/components/charts/ChartsServer.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Charts from './Charts';
+import db from '@/lib/db';
+
+interface Props {
+  linkCount: number;
+  teamId: string;
+}
+
+async function getTeamLinksCountByMonth(teamId: string) {
+  // Safe from SQL injection --> https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access#queryraw
+  const result = await db.$queryRaw`SELECT
+    CAST(EXTRACT(MONTH FROM b."createdAt") AS INTEGER) AS month,
+    CAST(COUNT(link."id") AS INTEGER) AS link_count
+FROM
+    bookmarks b
+JOIN
+    links link ON b."linkId" = link."id"
+JOIN
+    teams t ON b."teamId" = t."id"
+WHERE
+    t."id" = ${teamId}
+    AND EXTRACT(YEAR FROM b."createdAt") = EXTRACT(YEAR FROM CURRENT_DATE)
+GROUP BY
+    month;`;
+
+  return result as Array<{
+    month: number;
+    link_count: number;
+  }>;
+}
+
+export default async function ChartsServer({ linkCount, teamId }: Props) {
+  const teamLinkCount = await getTeamLinksCountByMonth(teamId);
+
+  return (
+    <div className="h-full flex flex-grow-0 w-ful items-end">
+      <p className="flex flex-col justify-end">
+        <span className="text-3xl font-bold">{linkCount}</span>
+        <span className="text-xs whitespace-nowrap">bookmarks</span>
+      </p>
+      <div className="h-[60px] w-full">
+        <Charts teamLinksByMonth={teamLinkCount} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/charts/ChartsSkeleton.tsx
+++ b/src/components/charts/ChartsSkeleton.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function ChartsSkeleton() {
+  return (
+    <div className="h-[60px] w-full">
+      <div className="w-[60px] h-full rounded-sm flex flex-col justify-end">
+        <div className="w-full h-[36px]"></div>
+        <div className="w-full h-[16px"></div>
+      </div>
+      <div className="w-full h-full  bg-gradient-to-r from-transparent via-gray-700/10 to-transparent -translate-x-full animate-[shimmer_2s_infinite]"></div>
+    </div>
+  );
+}

--- a/src/components/charts/ChartsTooltip.tsx
+++ b/src/components/charts/ChartsTooltip.tsx
@@ -19,7 +19,7 @@ const getMonthFullName = (index: number): MonthLongName => {
   return MONTH_LONG_NAMES[index];
 };
 
-const Tooltip = ({
+const ChartsTooltip = ({
   active,
   payload,
   label,
@@ -46,4 +46,4 @@ const Tooltip = ({
   }
 };
 
-export default Tooltip;
+export default ChartsTooltip;

--- a/src/components/charts/Tooltip.tsx
+++ b/src/components/charts/Tooltip.tsx
@@ -1,0 +1,49 @@
+const MONTH_LONG_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+type MonthLongName = (typeof MONTH_LONG_NAMES)[number];
+
+const getMonthFullName = (index: number): MonthLongName => {
+  return MONTH_LONG_NAMES[index];
+};
+
+const Tooltip = ({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{
+    value: number;
+  }>;
+  label?: any;
+}) => {
+  const year = new Date().getFullYear();
+  if (active && payload && payload.length) {
+    return (
+      <div className="overflow-hidden  rounded-lg bg-white shadow p-3 flex flex-col gap-2">
+        <p className="text-sm text-gray-500">{`${getMonthFullName(
+          label
+        )} ${year}`}</p>
+        <div className="flex items-center justify-start gap-2">
+          <span className="w-[20px] h-[2px] bg-violet-400 content-[''] inline-block relative -bottom-[1px]" />
+          <span className="text-sm">{payload[0].value} bookmarked </span>
+        </div>
+      </div>
+    );
+  }
+};
+
+export default Tooltip;

--- a/src/components/digests/Digests.tsx
+++ b/src/components/digests/Digests.tsx
@@ -1,3 +1,4 @@
+'use client';
 import useTransitionRefresh from '@/hooks/useTransitionRefresh';
 import { TeamDigestsResult } from '@/lib/queries';
 import { CheckIcon, ChartBarIcon } from '@heroicons/react/24/solid';
@@ -44,7 +45,8 @@ export const Digests = ({ digests, teamSlug }: Props) => {
               {digest.publishedAt ? (
                 <>
                   <div className="flex items-center">
-                    <CheckIcon className="text-green-600 h-4 w-4 mr-1" /> Published
+                    <CheckIcon className="text-green-600 h-4 w-4 mr-1" />{' '}
+                    Published
                   </div>
                   <time className="text-gray-500 pl-1">
                     - {formatDate(digest.publishedAt!, 'MMMM dd, yyyy')}
@@ -58,11 +60,14 @@ export const Digests = ({ digests, teamSlug }: Props) => {
                 {`${bookmarkCount} bookmark${bookmarkCount > 1 ? 's' : ''}`}
               </div>
             </div>
-            {digest.publishedAt && digest.views > 0 && <div className="flex items-center text-sm text-gray-400">
-              <div className="flex items-center">
-                <ChartBarIcon className="text-gray-400 h-4 w-4 mr-1" /> {`${digest.views} view${digest.views > 1 ? 's' : ''}`}
+            {digest.publishedAt && digest.views > 0 && (
+              <div className="flex items-center text-sm text-gray-400">
+                <div className="flex items-center">
+                  <ChartBarIcon className="text-gray-400 h-4 w-4 mr-1" />{' '}
+                  {`${digest.views} view${digest.views > 1 ? 's' : ''}`}
+                </div>
               </div>
-            </div>}
+            )}
           </div>
         );
       })}

--- a/src/components/digests/templates/SelectTemplateModal.tsx
+++ b/src/components/digests/templates/SelectTemplateModal.tsx
@@ -1,3 +1,4 @@
+'use client';
 import Button from '@/components/Button';
 import { Dialog, DialogTrigger, DialogContent } from '@/components/Dialog';
 import { Digest, Team } from '@prisma/client';

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -1,4 +1,3 @@
-'use client';
 import { TeamDigestsResult, TeamLinks, getTeamBySlug } from '@/lib/queries';
 import { BsFillBookmarkFill } from '@react-icons/all-files/bs/BsFillBookmarkFill';
 import Link from 'next/link';
@@ -12,6 +11,9 @@ import NoContent from '../layout/NoContent';
 import PageContainer from '../layout/PageContainer';
 import Pagination from '../list/Pagination';
 import SelectTemplateModal from '../digests/templates/SelectTemplateModal';
+import ChartsServer from '../charts/ChartsServer';
+import { Suspense } from 'react';
+import ChartsSkeleton from '../charts/ChartsSkeleton';
 
 type Props = {
   linkCount: number;
@@ -37,14 +39,21 @@ const Team = ({
       <div className="flex max-lg:flex-col gap-5 pb-4">
         <Card
           className="w-full lg:w-2/3"
+          contentClassName="sm:py-2 sm:px-6"
           header={
-            <div className="flex items-center justify-between gap-3 max-sm:flex-col max-sm:items-start">
-              <div className="flex items-center gap-3 h-8">
-                <h2 className="text-xl">Bookmarks</h2>
-                <CounterTag count={linkCount} />
+            <>
+              <div className="flex items-center justify-between gap-3 max-sm:flex-col max-sm:items-start">
+                <div className="flex items-center gap-3 h-8">
+                  <h2 className="text-xl">Bookmarks</h2>
+                  {/* <CounterTag count={linkCount} /> */}
+                </div>
+
+                <BookmarksListControls linkCount={linkCount} />
               </div>
-              <BookmarksListControls linkCount={linkCount} />
-            </div>
+              <Suspense fallback={<ChartsSkeleton />}>
+                <ChartsServer linkCount={linkCount} teamId={team.id} />
+              </Suspense>
+            </>
           }
           footer={
             <div className="flex items-center justify-end">

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -257,6 +257,21 @@ export const getTeamLinks = async (
   };
 };
 
+/**
+ * Returns the number links of a team, (all links, not only the ones in the team page)
+ */
+export const countAllTeamLinks = async (teamId: string) => {
+  return db.link.count({
+    where: {
+      bookmark: {
+        some: {
+          teamId,
+        },
+      },
+    },
+  });
+};
+
 export type TeamLinksData = Awaited<ReturnType<typeof getTeamLinks>>;
 
 export type TeamLinks = TeamLinksData['teamLinks'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,10 +3921,11 @@ brotli@^1.3.3:
   dependencies:
     base64-js "^1.1.2"
 
-browser-request@*:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz#9ece5b5aca89a29932242e18bf933def9876cc17"
-  integrity sha512-YyNI4qJJ+piQG6MMEuo7J3Bzaqssufx04zpEKYfSrl/1Op59HWali9zMtBpXnkmqMcOuWJPZvudrm9wISmnCbg==
+"browser-request@github:postlight/browser-request#feat-add-headers-to-response":
+  version "0.3.2"
+  resolved "https://codeload.github.com/postlight/browser-request/tar.gz/38faa5b85741aabfca61aa37d1ef044d68969ddf"
+  dependencies:
+    http-headers "^3.0.1"
 
 browserslist@^4.21.10, browserslist@^4.21.9:
   version "4.22.1"
@@ -6777,6 +6778,13 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-headers@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/http-headers/-/http-headers-3.0.2.tgz#5147771292f0b39d6778d930a3a59a76fc7ef44d"
+  integrity sha512-87E1I+2Wg4dxxz4rcxElo3dxO/w1ZtgL1yA0Sb6vH3qU16vRKq1NjWQv9SCY3ly2OQROcoxHZOUpmelS+k6wOw==
+  dependencies:
+    next-line "^1.1.0"
+
 http-proxy-agent@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz#e9096c5afd071a3fce56e6252bb321583c124673"
@@ -7832,7 +7840,7 @@ jose@^4.11.4, jose@^4.15.1:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
   integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
 
-jquery@*:
+jquery@^3.5.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
@@ -9571,14 +9579,14 @@ moment-parseformat@3.0.0:
   resolved "https://registry.yarnpkg.com/moment-parseformat/-/moment-parseformat-3.0.0.tgz#3a1dc438b4bc073b7e93cc298cfb6c5daac26dba"
   integrity sha512-dVgXe6b6DLnv4CHG7a1zUe5mSXaIZ3c6lSHm/EKeVeQI2/4pwe0VRde8OyoCE1Ro2lKT5P6uT9JElF7KDLV+jw==
 
-moment-timezone@*:
-  version "0.5.43"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
-  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
+moment-timezone@0.5.37:
+  version "0.5.37"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.37.tgz#adf97f719c4e458fdb12e2b4e87b8bec9f4eef1e"
+  integrity sha512-uEDzDNFhfaywRl+vwXxffjjq1q0Vzr+fcQpQ1bU0kbzorfS7zVtZnCnGc8mhWmF39d4g4YriF6kwA75mJKE/Zg==
   dependencies:
-    moment "^2.29.4"
+    moment ">= 2.9.0"
 
-moment@^2.23.0, moment@^2.29.4:
+"moment@>= 2.9.0", moment@^2.23.0:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -9684,6 +9692,11 @@ next-contentlayer@^0.3.2:
   dependencies:
     "@contentlayer/core" "0.3.4"
     "@contentlayer/utils" "0.3.4"
+
+next-line@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-line/-/next-line-1.1.0.tgz#fcae57853052b6a9bae8208e40dd7d3c2d304603"
+  integrity sha512-+I10J3wKNoKddNxn0CNpoZ3eTZuqxjNM3b1GImVx22+ePI+Y15P8g/j3WsbP0fhzzrFzrtjOAoq5NCCucswXOQ==
 
 next-superjson-plugin@^0.5.8:
   version "0.5.9"
@@ -10946,6 +10959,21 @@ recharts@^2.9.0:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.9.2.tgz#a6a4e4c2887467ea57abde7e3af5c8021355a606"
   integrity sha512-ig0zYgO5nUP/896GW16b9yy2sHIRW1AHB90x48hypFTSjjxQt/J9rPzlLJjgNupzJKEHPCwMi1VnvN/k20K45w==
+  dependencies:
+    classnames "^2.2.5"
+    eventemitter3 "^4.0.1"
+    lodash "^4.17.19"
+    react-is "^16.10.2"
+    react-resize-detector "^8.0.4"
+    react-smooth "^2.0.4"
+    recharts-scale "^0.4.4"
+    tiny-invariant "^1.3.1"
+    victory-vendor "^36.6.8"
+
+recharts@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.9.3.tgz#cb96105ba9c0b8d0fdb44613cbcbf8e0e5b505b3"
+  integrity sha512-B61sKrDlTxHvYwOCw8eYrD6rTA2a2hJg0avaY8qFI1ZYdHKvU18+J5u7sBMFg//wfJ/C5RL5+HsXt5e8tcJNLg==
   dependencies:
     classnames "^2.2.5"
     eventemitter3 "^4.0.1"


### PR DESCRIPTION
## Add bookmarked link metrics in Team Page
### Description
This pull request adds a graphical interface to the team's dashboard page, displaying graphs and charts that count and group all bookmarks per month. This enhancement enables users to visualize their team's contributions over time.
### Link to issue
Fix #64 

### Screenshots
<img width="1273" alt="image" src="https://github.com/premieroctet/digestclub/assets/51860690/46c64777-4301-4263-be36-fbcecf05298d">

### Additional Comments
I utilized Raw SQL since Prisma currently lacks support for grouping by date ranges or formatting dates directly within a `groupBy`. Additionally, I lowered the "level" in the React Tree where client rendering takes place to enable server-side rendering of the chart. As a result, `src/components/pages/Team.tsx` is now server-side rendered.





