### PR TITLE
Fix notFound error in team page

### DIFF
--- a/src/app/(routes)/[teamSlug]/page.tsx
+++ b/src/app/(routes)/[teamSlug]/page.tsx
@@ -2,8 +2,9 @@ import TeamPublicPage from '@/components/pages/TeamPublicPage';
 import { getDiscoverDigests, getTeamBySlug } from '@/lib/queries';
 import { getEnvHost } from '@/lib/server';
 import { generateTeamOGUrl } from '@/utils/open-graph-url';
+import { isPrismaNotFoundError } from '@/utils/prisma';
 import { Metadata } from 'next';
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -15,56 +16,75 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  const team = await getTeamBySlug(params.teamSlug);
-  const url = generateTeamOGUrl(team?.slug || '');
+  try {
+    const team = await getTeamBySlug(params.teamSlug);
+    const url = generateTeamOGUrl(team?.slug || '');
 
-  return {
-    alternates: {
-      types: {
-        'application/rss+xml': `${getEnvHost()}/${params.teamSlug}/rss.xml`,
-        'application/atom+xml': `${getEnvHost()}/${params.teamSlug}/atom.xml`,
-      },
-    },
-    title: `${team?.name}`,
-    twitter: {
-      card: 'summary_large_image',
-      title: `${team?.name}`,
-      description: team?.bio || team?.name,
-      images: [url],
-    },
-    openGraph: {
-      type: 'website',
-      title: `${team?.name}`,
-      description: team?.bio || team?.name,
-      url,
-      images: [
-        {
-          url,
-          width: 1200,
-          height: 600,
+    return {
+      alternates: {
+        types: {
+          'application/rss+xml': `${getEnvHost()}/${params.teamSlug}/rss.xml`,
+          'application/atom+xml': `${getEnvHost()}/${params.teamSlug}/atom.xml`,
         },
-      ],
-    },
-  };
+      },
+      title: `${team?.name}`,
+      twitter: {
+        card: 'summary_large_image',
+        title: `${team?.name}`,
+        description: team?.bio || team?.name,
+        images: [url],
+      },
+      openGraph: {
+        type: 'website',
+        title: `${team?.name}`,
+        description: team?.bio || team?.name,
+        url,
+        images: [
+          {
+            url,
+            width: 1200,
+            height: 600,
+          },
+        ],
+      },
+    };
+  } catch (error) {
+    if (isPrismaNotFoundError(error)) {
+      notFound();
+    } else {
+      throw error;
+    }
+  }
 }
 
 const PublicTeamPage = async ({ params, searchParams }: PageProps) => {
-  const team = await getTeamBySlug(params.teamSlug);
+  try {
+    const team = await getTeamBySlug(params.teamSlug);
 
-  if (!team) return null;
-  const page = Number(searchParams?.page || 1);
-  const { digests, digestsCount } = await getDiscoverDigests({
-    page,
-    perPage: 10,
-    teamId: team?.id,
-  });
+    const page = Number(searchParams?.page || 1);
+    const { digests, digestsCount } = await getDiscoverDigests({
+      page,
+      perPage: 10,
+      teamId: team?.id,
+    });
 
-  if (!team) {
-    redirect('/');
+    if (!team) {
+      redirect('/');
+    }
+    return (
+      <TeamPublicPage
+        team={team}
+        digests={digests}
+        digestsCount={digestsCount}
+      />
+    );
+  } catch (error: any) {
+    if (isPrismaNotFoundError(error)) {
+      notFound();
+    } else {
+      throw error;
+    }
   }
-  return (
-    <TeamPublicPage team={team} digests={digests} digestsCount={digestsCount} />
-  );
 };
 
 export default PublicTeamPage;

--- a/src/utils/prisma.ts
+++ b/src/utils/prisma.ts
@@ -1,0 +1,5 @@
+export const PRISMA_NOT_FOUND_ERROR_CODES = ['P2018', 'P2025'];
+
+export function isPrismaNotFoundError(error: any) {
+  return PRISMA_NOT_FOUND_ERROR_CODES.includes(error.code);
+}


### PR DESCRIPTION
## Add bookmarked link metrics in Team Page
### Description
Fix NotFound that wasn't triggered here: [should-return-404](https://digest.club/should-return-404)

### Link to issue
Fix #74

### Additional Comments
**TLDR:** _It's not exactly our 'usual' not found pattern because `FindFirstOrThrow` allows us to correctly type the props of the components. So, we let Prisma throw the error._

I could have used the pattern we use elsewhere in the application, where we don't let Prisma throw the "not found' error
```tsx
const Page = async () => {
  const user = await getCurrentUser();
  if (!user) return notFound();

  return (
    <div>
      <div className="flex flex-col space-y-6 content-stretch">
        <Component user={user!} />
      </div>
    </div>
  );
};
```

However, I would need to update the `getTeamBySlug` function, which is currently `db.team.findFirstOrThrow(...)` to `db.team.findFirst(...)`.
This would make all types of team derived from the return of the getTeamBySlug function ([see](https://github.com/premieroctet/digestclub/blob/e8ab47c55724816b67370a864b17e55a5e960f0f/src/components/digests/BlockListDnd.tsx#L11)) potentially undefined.

So instead, we catch the Prisma error, look if it's a "not found" error. If it's a "not found" error we call `notFound()` else we throw error (internal server error / 500).

