### PR TITLE
feat(seo): add sitemap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           echo NEXTAUTH_SECRET="RANDOMEKEY" >> .env
           echo JWT_SECRET="RANDOMEKEY" >> .env
           echo OPENAI_API_KEY="RANDOMEKEY" >> .env
+          echo SKIP_SITEMAP_GENERATION="true" >> .env
           cat .env
       - name: Install dependencies
         run: yarn install

--- a/src/app/robot.ts
+++ b/src/app/robot.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from 'next';
+
+const siteUrl = process.env.VERCEL_URL || 'https://digest.club';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      disallow: ['/admin', '/unsubscribe', '/auth/login', '/teams'],
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next';
-const siteUrl = 'https://digest.club';
+const siteUrl = process.env.VERCEL_URL || 'https://digest.club';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,89 @@
+import db from '@/lib/db';
 import { MetadataRoute } from 'next';
 const siteUrl = process.env.VERCEL_URL || 'https://digest.club';
 
-export default function sitemap(): MetadataRoute.Sitemap {
+interface TeamData {
+  slug: string;
+  updatedAt: Date;
+}
+
+async function getTeamsData() {
+  const teams = await db.team.findMany({
+    select: {
+      slug: true,
+      Digest: {
+        select: {
+          updatedAt: true,
+        },
+        orderBy: {
+          updatedAt: 'desc',
+        },
+      },
+    },
+  });
+  return teams.map((team) => {
+    return {
+      slug: team.slug,
+      updatedAt: team.Digest[0]?.updatedAt,
+    };
+  });
+}
+
+function getTeamRoutes(teamsData: TeamData[]): MetadataRoute.Sitemap {
+  return teamsData.map(({ slug, updatedAt }) => ({
+    url: `${siteUrl}/teams/${slug}`,
+    lastModified: updatedAt,
+    changeFrequency: 'weekly',
+    priority: 0.8,
+  }));
+}
+
+async function getDigestsSlugsOfTeam(teamSlug: string) {
+  return db.digest.findMany({
+    where: {
+      AND: [
+        {
+          team: {
+            slug: teamSlug,
+          },
+        },
+        {
+          NOT: {
+            publishedAt: null,
+          },
+        },
+      ],
+    },
+    select: {
+      slug: true,
+      updatedAt: true,
+    },
+  });
+}
+
+async function getDigestRoutes(teamsData: TeamData[]) {
+  const digestsSiteMap: MetadataRoute.Sitemap = [];
+  const promises = teamsData.map(async ({ slug: teamSlug }) => {
+    const digests = await getDigestsSlugsOfTeam(teamSlug);
+    digests.forEach((digest) => {
+      digestsSiteMap.push({
+        url: `${siteUrl}/${teamSlug}/${digest.slug}`,
+        lastModified: digest.updatedAt,
+        changeFrequency: 'weekly',
+        priority: 0.8,
+      });
+    });
+  });
+
+  await Promise.all(promises);
+  return digestsSiteMap;
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const teamsData = await getTeamsData();
+  const teamRoutes = getTeamRoutes(teamsData);
+  const digestRoutes = await getDigestRoutes(teamsData);
+
   return [
     {
       url: siteUrl,
@@ -12,8 +94,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     {
       url: `${siteUrl}/updates`,
       lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.6,
+      changeFrequency: 'monthly',
+      priority: 0.5,
     },
     {
       url: `${siteUrl}/discover`,
@@ -25,13 +107,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: `${siteUrl}/auth/login`,
       lastModified: new Date(),
       changeFrequency: 'yearly',
-      priority: 0.7,
+      priority: 0.4,
     },
     {
       url: `${siteUrl}/unsubscribe`,
       lastModified: new Date(),
       changeFrequency: 'yearly',
-      priority: 0.7,
+      priority: 0.2,
     },
+    ...teamRoutes,
+    ...digestRoutes,
   ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import db from '@/lib/db';
 import { MetadataRoute } from 'next';
 const siteUrl = process.env.VERCEL_URL || 'https://digest.club';
+const skipSitemap = process.env.SKIP_SITEMAP_GENERATION === 'true';
 
 interface TeamData {
   slug: string;
@@ -80,6 +81,9 @@ async function getDigestRoutes(teamsData: TeamData[]) {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  if (skipSitemap) {
+    return [];
+  }
   const teamsData = await getTeamsData();
   const teamRoutes = getTeamRoutes(teamsData);
   const digestRoutes = await getDigestRoutes(teamsData);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,49 @@
+import { MetadataRoute } from 'next';
+const siteUrl = 'https://digest.club';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/updates`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    },
+    {
+      url: `${siteUrl}/discover`,
+      lastModified: new Date(),
+      changeFrequency: 'always',
+      priority: 0.7,
+    },
+    {
+      url: `${siteUrl}/account`,
+      lastModified: new Date(),
+      changeFrequency: 'always',
+      priority: 0.7,
+    },
+    {
+      url: `${siteUrl}/auth/login`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.7,
+    },
+    {
+      url: `${siteUrl}/unsubscribe`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.7,
+    },
+    {
+      url: `${siteUrl}/teams/create`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.7,
+    },
+  ];
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,12 +22,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
-      url: `${siteUrl}/account`,
-      lastModified: new Date(),
-      changeFrequency: 'always',
-      priority: 0.7,
-    },
-    {
       url: `${siteUrl}/auth/login`,
       lastModified: new Date(),
       changeFrequency: 'yearly',
@@ -35,12 +29,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: `${siteUrl}/unsubscribe`,
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
-      priority: 0.7,
-    },
-    {
-      url: `${siteUrl}/teams/create`,
       lastModified: new Date(),
       changeFrequency: 'yearly',
       priority: 0.7,


### PR DESCRIPTION
## Add sitemap and robot.txt
### Description
Add sitemap to the app, following [official NextJS documentation](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap). 
[And robot.txt](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots)

### Link issue
Fix #75

### Additional comments

From NextJS documentation:
_In the future, we will support multiple sitemaps and sitemap indexes._

Added `SKIP_SITEMAP_GENERATION` in the Github Action test workflow, so this workflow will not need access to the database

