### PR TITLE
Fix(api): bookmark endpoint

### DIFF
--- a/src/pages/api/bookmark/index.ts
+++ b/src/pages/api/bookmark/index.ts
@@ -10,6 +10,9 @@ export type ApiBookmarkResponseSuccess = Bookmark;
 
 export const router = createRouter<AuthApiRequest, NextApiResponse>();
 
+interface PostRequestBody {
+  linkUrl: string;
+}
 router.post(async (req, res) => {
   if (!process.env.JWT_SECRET) return res.status(500).end();
   if (
@@ -25,7 +28,7 @@ router.post(async (req, res) => {
     const { teamId } = decoded as { teamId: string };
     if (!teamId) return res.status(401).end();
 
-    const { linkUrl } = JSON.parse(req.body);
+    const { linkUrl } = req.body as PostRequestBody;
     if (!linkUrl) return res.status(400).end();
 
     try {


### PR DESCRIPTION
# Fix for Bookmark API Endpoint
## Description
The `req.body` was incorrectly typed; it is a JavaScript object, not a string. Therefore, there is no need to parse it.
## Link to the Issue
Fixes #57
