### PR TITLE
Fix(bookmark): restrict bookmark links to pdf and text only

### DIFF
--- a/src/messages/en.ts
+++ b/src/messages/en.ts
@@ -287,6 +287,7 @@ const message = {
         already_bookmarked:
           'You have already bookmarked this link in this team',
         invalid_link: 'Invalid link provided',
+        invalid_content_type: 'Invalid content type, only text or pdf allowed',
       },
     },
   },

--- a/src/utils/bookmark.ts
+++ b/src/utils/bookmark.ts
@@ -102,8 +102,10 @@ export const saveBookmark = async (
 
   if (!link) {
     const isPDF = response.headers.get('Content-Type') === 'application/pdf';
+    const isText = response.headers.get('Content-Type')?.startsWith('text/');
     let blurhash = null;
     let metadata = null;
+    if (!isPDF && !isText) throw new TypeError('invalid_content_type');
 
     if (!isPDF) {
       metadata = await extractMetadata(linkUrl);
@@ -119,7 +121,7 @@ export const saveBookmark = async (
       } catch (e) {}
     }
 
-    const logo = isPDF ? 'hello' : metadata?.logo ?? null;
+    const logo = isPDF ? null : metadata?.logo;
 
     link = await db.link.create({
       data: {


### PR DESCRIPTION
## Fix
### Description
Only allows pdf and text content type (website) as saved bookmark
### Link issue
Fix #49 