### PR TITLE
Feat(API): Add rate limiting and error handling to bookmark API

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "husky": "^8.0.3",
     "jsonwebtoken": "^9.0.1",
     "lodash": "^4.17.21",
+    "lru-cache": "^10.0.2",
     "metascraper": "^5.36.0",
     "metascraper-description": "^5.33.7",
     "metascraper-image": "^5.33.7",

--- a/src/utils/apiError.tsx
+++ b/src/utils/apiError.tsx
@@ -1,0 +1,39 @@
+export const ApiErrorMessages = {
+  INTERNAL_SERVER_ERROR: 'Internal Server Error',
+  UNAUTHORIZED: 'Unauthorized',
+  RATE_LIMIT_EXCEEDED: 'Rate Limit Exceeded',
+  MISSING_PARAMETERS: 'Missing Parameters',
+} as const;
+
+type ApiErrorMessagesType =
+  (typeof ApiErrorMessages)[keyof typeof ApiErrorMessages];
+
+export class ApiError extends Error {
+  constructor(message: ApiErrorMessagesType, public status: number) {
+    super(message);
+  }
+}
+
+export class UnauthorizedError extends ApiError {
+  constructor() {
+    super(ApiErrorMessages.UNAUTHORIZED, 401);
+  }
+}
+
+export class MissingParametersError extends ApiError {
+  constructor() {
+    super(ApiErrorMessages.MISSING_PARAMETERS, 400);
+  }
+}
+
+export class RateLimitExceedError extends ApiError {
+  constructor() {
+    super(ApiErrorMessages.RATE_LIMIT_EXCEEDED, 429);
+  }
+}
+
+export class InternalServerError extends ApiError {
+  constructor() {
+    super(ApiErrorMessages.INTERNAL_SERVER_ERROR, 500);
+  }
+}

--- a/src/utils/bookmark.ts
+++ b/src/utils/bookmark.ts
@@ -31,12 +31,8 @@ const getHtml = async (url: string) => {
   });
 };
 
-const isBookmarkedByUser = async (
-  linkId?: string,
-  membershipId?: string,
-  teamId?: string
-) => {
-  if (!linkId || !membershipId || !teamId) return;
+const isBookmarkAlreadyInTeam = async (linkId?: string, teamId?: string) => {
+  if (!linkId || !teamId) return;
 
   return db.bookmark
     .findFirst({
@@ -44,9 +40,6 @@ const isBookmarkedByUser = async (
       where: {
         linkId: {
           equals: linkId,
-        },
-        membershipId: {
-          equals: membershipId,
         },
         teamId: {
           equals: teamId,
@@ -98,7 +91,7 @@ export const saveBookmark = async (
   });
 
   const response = await isLinkValid(linkUrl);
-  await isBookmarkedByUser(link?.id, membershipId, teamId);
+  await isBookmarkAlreadyInTeam(link?.id, teamId);
 
   if (!link) {
     const isPDF = response.headers.get('Content-Type') === 'application/pdf';

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -1,0 +1,40 @@
+import type { NextApiResponse } from 'next';
+import { LRUCache } from 'lru-cache';
+import { RateLimitExceedError } from './apiError';
+
+type Options = {
+  uniqueTokenPerInterval?: number;
+  interval?: number;
+};
+
+// from : https://github.com/vercel/next.js/blob/canary/examples/api-routes-rate-limit/utils/rate-limit.ts
+/**
+ * Rate limit a request by a given key and a given time window
+ */
+export default function rateLimit(options?: Options) {
+  const tokenCache = new LRUCache({
+    max: options?.uniqueTokenPerInterval || 500,
+    ttl: options?.interval || 60000,
+  });
+
+  return {
+    check: (res: NextApiResponse, limit: number, token: string) =>
+      new Promise<void>((resolve, reject) => {
+        const tokenCount = (tokenCache.get(token) as number[]) || [0];
+        if (tokenCount[0] === 0) {
+          tokenCache.set(token, tokenCount);
+        }
+        tokenCount[0] += 1;
+
+        const currentUsage = tokenCount[0];
+        const isRateLimited = currentUsage >= limit;
+        res.setHeader('X-RateLimit-Limit', limit);
+        res.setHeader(
+          'X-RateLimit-Remaining',
+          isRateLimited ? 0 : limit - currentUsage
+        );
+
+        return isRateLimited ? reject(new RateLimitExceedError()) : resolve();
+      }),
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8381,6 +8381,13 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.2.tgz#34504678cc3266b09b8dfd6fab4e1515258271b7"
+  integrity sha512-Yj9mA8fPiVgOUpByoTZO5pNrcl5Yk37FcSHsUINpAsaBIEZIuqcCclDZJCVxqQShDsmYX8QG63svJiTbOATZwg==
+  dependencies:
+    semver "^7.3.5"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"


### PR DESCRIPTION
- added a rate limit pattern (that can be found [here](https://github.com/vercel/next.js/blob/canary/examples/api-routes-rate-limit/utils/rate-limit.ts)) to handle DDOS attack
- added better error handling for API errors
- updated the `saveBookmark`, all links added in a specific team must be unique (not tied to user anymore)