### PR TITLE
Make the right panel sticky to easy drag & drop

### DIFF
--- a/src/components/pages/DigestEditPage.tsx
+++ b/src/components/pages/DigestEditPage.tsx
@@ -309,7 +309,7 @@ export const DigestEditPage = ({
             </SectionContainer>
           </div>
 
-          <SectionContainer className={clsx(' w-full h-min md:w-1/2')}>
+          <SectionContainer className={clsx(' w-full h-min md:w-1/2 sticky top-4')}>
             <form className="flex flex-col gap-5" onBlur={handleSubmit(onBlur)}>
               <div className="w-full items-start flex flex-col gap-6">
                 <Input


### PR DESCRIPTION
I did not test but it works in the devtools editor.

![image](https://github.com/premieroctet/digestclub/assets/225704/c1050659-4173-4ab7-9e42-7f8d4a6b71f0)

With a sticky panel it's easier to drag & drop a link with we did scroll.