### PR TITLE
fix: dont display teams with empty digest

### DIFF
--- a/src/components/ActiveTeams.tsx
+++ b/src/components/ActiveTeams.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import TeamAvatar from './teams/TeamAvatar';
 import Link from 'next/link';
+import TeamAvatar from './teams/TeamAvatar';
 
 interface Props {
   teams: {
@@ -10,7 +9,10 @@ interface Props {
   }[];
 }
 export default function ActiveTeams({ teams }: Props) {
-  if (teams.length === 0) return <></>;
+  if (teams.length === 0) {
+    return <></>;
+  }
+
   return (
     <div className="bg-white p-4 border border-gray-200 rounded-lg">
       <h4 className="text-xl font-bold">Active Teams</h4>

--- a/src/services/database/team.ts
+++ b/src/services/database/team.ts
@@ -103,8 +103,13 @@ export const getPublicTeam = (slug: string) =>
 export const getRecentTeams = async () => {
   const digests = await db.digest.findMany({
     take: 5,
-    select: { team: { select: { name: true, slug: true, color: true } } },
-    where: { publishedAt: { not: null } },
+    select: {
+      team: { select: { name: true, slug: true, color: true } },
+    },
+    where: {
+      publishedAt: { not: null },
+      digestBlocks: { some: {} },
+    },
     orderBy: { publishedAt: 'desc' },
     distinct: ['teamId'],
   });


### PR DESCRIPTION
Do not display teams with empty digest in the Discover section