### PR TITLE
Fix: Add Font (Mulish)

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { getUserTeams } from '@/services/database/team';
 import '@/theme/app.css';
 import '@/theme/globals.css';
 import { Metadata } from 'next';
+import { Mulish } from 'next/font/google';
 import Providers from './providers';
 
 export const dynamic = 'force-dynamic';
@@ -47,6 +48,12 @@ export const metadata: Metadata = {
   },
 };
 
+const mulish = Mulish({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-mulish',
+});
+
 export default async function RootLayout({ children }: Props) {
   const session = await getSession();
   const teams = session?.user.id
@@ -55,7 +62,9 @@ export default async function RootLayout({ children }: Props) {
 
   return (
     <html lang="en">
-      <body className="flex flex-col font-sans overflow-x-hidden">
+      <body
+        className={`flex flex-col font-sans overflow-x-hidden ${mulish.variable} font-mulish`}
+      >
         <Providers>
           <Header teams={teams} user={session?.user} />
           {children}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,9 @@ module.exports = {
       xs: '480px',
       ...defaultTheme.screens,
     },
+    fontFamily: {
+      mulish: 'var(--font-mulish)',
+    },
     extends: {
       typography: ({ theme }) => ({
         violet: {
@@ -47,8 +50,13 @@ module.exports = {
             '--tw-prose-invert-td-borders': theme('colors.violet[700]'),
           },
         },
-      })
-    }
+      }),
+    },
   },
-  plugins: [require('@tailwindcss/forms'), require('tailwindcss-animate'), require('@tailwindcss/line-clamp'), require('@tailwindcss/typography')],
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('tailwindcss-animate'),
+    require('@tailwindcss/line-clamp'),
+    require('@tailwindcss/typography'),
+  ],
 };


### PR DESCRIPTION
Fix #127 
## Changes in this PR
- Add font for the website -> **Mulish**
Other possible typefaces were Poppins, Roboto. However, I believe Mulish is the best compromise. It displays numbers in a classic way, is not too bold, and is quite gentle to read

## Screenshots

### Mulish ✅
![mul](https://github.com/premieroctet/digestclub/assets/51860690/2155e31e-cd5b-465a-96e3-512e9c12505c)

### Roboto
Could work as well
![roboto](https://github.com/premieroctet/digestclub/assets/51860690/2b6226b9-c616-4b86-aaa6-af90271a4f7e)

### Poppins ❌
Too bold
![pop](https://github.com/premieroctet/digestclub/assets/51860690/6f354aff-3fb6-46ef-9412-f17a12eab8e8)

