### PR TITLE
Fix switch input

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,6 +1,6 @@
 'use client';
 import clsx from 'clsx';
-import { forwardRef, HTMLProps, useState } from 'react';
+import { forwardRef, HTMLProps } from 'react';
 
 export const Input = forwardRef<HTMLInputElement, HTMLProps<HTMLInputElement>>(
   function Input({ className, ...props }, ref) {
@@ -65,16 +65,14 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps<any>>(
 
 export const Switch = forwardRef<HTMLInputElement, HTMLProps<HTMLInputElement>>(
   function Switch({ label, onChange, checked, ...props }, ref) {
-    const [isChecked, setIsChecked] = useState(checked);
     return (
       <label className="relative inline-flex  cursor-pointer">
         <div className="flex-1">
           <input
             type="checkbox"
-            checked={isChecked}
+            checked={checked}
             className="sr-only peer"
             onChange={(e) => {
-              setIsChecked(!isChecked);
               onChange && onChange(e);
             }}
             ref={ref}
@@ -84,7 +82,7 @@ export const Switch = forwardRef<HTMLInputElement, HTMLProps<HTMLInputElement>>(
         </div>
         <span
           className={`ml-3 text-sm font-medium text-gray-900 dark:text-gray-300 ${
-            !isChecked ? 'opacity-60' : 'opacity-100'
+            !checked ? 'opacity-60' : 'opacity-100'
           }`}
         >
           {label}


### PR DESCRIPTION
## Bug description
Checked state was internally managed instead of being controlled by parent
This was causing some sync issue in a page that as the same switch twice (ex: https://digest.club/teams/[teamSlug])

## How to reproduce
1) Go to https://digest.club/teams/[teamSlug]
2) Click on the top _View all bookmarks_ switch
3) The bottom _View all bookmarks_ switch is not checked 

## Fix
Now the switch is a controlled component

## Screenshots
![image](https://github.com/premieroctet/digestclub/assets/51860690/f2f4c2ff-689e-4b5e-8154-9c891a13bb6a)
![image](https://github.com/premieroctet/digestclub/assets/51860690/429cefae-716f-4605-ba6d-d613145da297)

