### PR TITLE
Feat: add a list of all tags to discover

### DIFF
--- a/src/app/(app)/(routes)/discover/page.tsx
+++ b/src/app/(app)/(routes)/discover/page.tsx
@@ -1,12 +1,10 @@
 import ActiveTeams from '@/components/ActiveTeams';
-import PopularTags from '@/components/PopularTags';
+import TagsList from '@/components/TagsList';
 import Pagination from '@/components/list/Pagination';
 import PublicDigestListItem from '@/components/teams/PublicDigestListItem';
-import TeamAvatar from '@/components/teams/TeamAvatar';
 import { getDiscoverDigests } from '@/services/database/digest';
-import { getPopularTags } from '@/services/database/tag';
+import { getAllTags, getPopularTags } from '@/services/database/tag';
 import { getRecentTeams } from '@/services/database/team';
-import Link from 'next/link';
 
 export interface TeamPageProps {
   params: { teamSlug: string };
@@ -20,6 +18,7 @@ const DiscoverPage = async ({ searchParams }: TeamPageProps) => {
 
   const recentTeams = await getRecentTeams();
   const popularTags = await getPopularTags();
+  const allTags = await getAllTags();
 
   const { digests, digestsCount } = await getDiscoverDigests({
     page,
@@ -52,7 +51,16 @@ const DiscoverPage = async ({ searchParams }: TeamPageProps) => {
         </div>
         <div className="flex flex-col gap-4 md:max-w-[22rem] w-full">
           <ActiveTeams teams={recentTeams} />
-          <PopularTags tags={popularTags} />
+          <TagsList
+            tags={popularTags}
+            title="Popular tags"
+            description="Browse digests by the most used tags"
+          />
+          <TagsList
+            tags={allTags}
+            title="Tags"
+            description="Browse digests by tags"
+          />
         </div>
       </div>
     </main>

--- a/src/app/(app)/(routes)/tags/[slug]/page.tsx
+++ b/src/app/(app)/(routes)/tags/[slug]/page.tsx
@@ -1,11 +1,16 @@
 import ActiveTeams from '@/components/ActiveTeams';
 import CustomLink from '@/components/Link';
-import PopularTags from '@/components/PopularTags';
+import TagsList from '@/components/TagsList';
 import Pagination from '@/components/list/Pagination';
 import PublicDigestListItem from '@/components/teams/PublicDigestListItem';
 import { getDiscoverDigests } from '@/services/database/digest';
-import { getPopularTags, getTagBySlug } from '@/services/database/tag';
+import {
+  getAllTags,
+  getPopularTags,
+  getTagBySlug,
+} from '@/services/database/tag';
 import { getRecentTeams } from '@/services/database/team';
+
 import { notFound } from 'next/navigation';
 export const dynamic = 'force-dynamic';
 
@@ -33,6 +38,7 @@ const TagsPage = async ({
     tagId: tag.id,
   });
   const popularTags = await getPopularTags();
+  const allTags = await getAllTags();
 
   return (
     <main className="max-w-6xl mx-auto mb-10">
@@ -84,8 +90,18 @@ const TagsPage = async ({
         </div>
         <div className="flex flex-col gap-4 md:max-w-[22rem] w-full">
           <ActiveTeams teams={recentTeams} />
-
-          <PopularTags tags={popularTags} currentTag={tag} />
+          <TagsList
+            tags={popularTags}
+            currentTag={tag}
+            title="Popular tags"
+            description="Browse digests by the most used tags"
+          />
+          <TagsList
+            tags={allTags}
+            currentTag={tag}
+            title="Tags"
+            description="Browse digests by tags"
+          />
         </div>
       </div>
     </main>

--- a/src/components/TagsList.tsx
+++ b/src/components/TagsList.tsx
@@ -5,16 +5,21 @@ import Tag, { ITag } from './Tag';
 interface Props {
   tags: ITag[];
   currentTag?: ITag;
+  title: string;
+  description: string;
 }
 
-export default function PopularTags({ tags, currentTag }: Props) {
+export default function TagsList({
+  tags,
+  currentTag,
+  title,
+  description,
+}: Props) {
   if (tags.length === 0) return <></>;
   return (
     <div className="bg-white p-4 border border-gray-200 rounded-lg">
-      <h4 className="text-xl font-bold">Popular tags</h4>
-      <p className="text-xs text-slate-500 mt-0.5">
-        Browse digests by the most used tags
-      </p>
+      <h4 className="text-xl font-bold">{title}</h4>
+      <p className="text-xs text-slate-500 mt-0.5">{description}</p>
       <div className="flex gap-2 mt-4 flex-wrap">
         {tags.map(({ id, name, slug, description }) => {
           const isActive = currentTag?.id === id;

--- a/src/services/database/tag.ts
+++ b/src/services/database/tag.ts
@@ -58,3 +58,17 @@ export const getPopularTags = async () => {
     throw new Error('Error getting popular tags');
   }
 };
+
+
+export const getAllTags = async () => {
+  try {
+    const tags = await db.tag.findMany({
+      orderBy: {
+        name: 'asc',
+      },
+    });
+    return tags;
+  } catch (error) {
+    throw new Error('Error getting all tags');
+  }
+};


### PR DESCRIPTION
Currently users don't have the possibility to easily browse digests from our full tags list
![Screenshot 2024-06-20 at 16 23 53](https://github.com/premieroctet/digestclub/assets/51860690/65dfa378-455a-4d6f-9b83-fd3c23d1c527)

This PR add a full tags list for users to browse
![image](https://github.com/premieroctet/digestclub/assets/51860690/0168499e-3ce8-4ee0-a90d-a7f76e673ea7)
